### PR TITLE
Image fixes

### DIFF
--- a/pkg/image/api/types.go
+++ b/pkg/image/api/types.go
@@ -14,12 +14,10 @@ type ImageList struct {
 
 // Image is an immutable representation of a Docker image and metadata at a point in time.
 type Image struct {
-	kapi.TypeMeta   `json:",inline" yaml:",inline"`
-	kapi.ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
-	// the our docker image repository hook needs to be updated to send name, but I don't know where lives.  I'm wiring this through for now
-	ID                   string       `json:"id,omitempty" yaml:"id,omitempty"`
+	kapi.TypeMeta        `json:",inline" yaml:",inline"`
+	kapi.ObjectMeta      `json:"metadata,omitempty" yaml:"metadata,omitempty"`
 	DockerImageReference string       `json:"dockerImageReference,omitempty" yaml:"dockerImageReference,omitempty"`
-	Metadata             docker.Image `json:"meta,omitempty" yaml:"meta,omitempty"`
+	DockerImageMetadata  docker.Image `json:"dockerImageMetadata,omitempty" yaml:"dockerImageMetadata,omitempty"`
 }
 
 // ImageRepositoryList is a list of ImageRepository objects.

--- a/pkg/image/api/v1beta1/types.go
+++ b/pkg/image/api/v1beta1/types.go
@@ -14,12 +14,10 @@ type ImageList struct {
 
 // Image is an immutable representation of a Docker image and metadata at a point in time.
 type Image struct {
-	kapi.TypeMeta   `json:",inline" yaml:",inline"`
-	kapi.ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
-	// the our docker image repository hook needs to be updated to send name, but I don't know where lives.  I'm wiring this through for now
-	ID                   string       `json:"id,omitempty" yaml:"id,omitempty"`
+	kapi.TypeMeta        `json:",inline" yaml:",inline"`
+	kapi.ObjectMeta      `json:"metadata,omitempty" yaml:"metadata,omitempty"`
 	DockerImageReference string       `json:"dockerImageReference,omitempty" yaml:"dockerImageReference,omitempty"`
-	Metadata             docker.Image `json:"meta,omitempty" yaml:"meta,omitempty"`
+	DockerImageMetadata  docker.Image `json:"dockerImageMetadata,omitempty" yaml:"dockerImageMetadata,omitempty"`
 }
 
 // ImageRepositoryList is a list of ImageRepository objects.

--- a/pkg/image/registry/etcd/etcd_test.go
+++ b/pkg/image/registry/etcd/etcd_test.go
@@ -216,7 +216,7 @@ func TestEtcdCreateImage(t *testing.T) {
 			Name: "foo",
 		},
 		DockerImageReference: "openshift/ruby-19-centos",
-		Metadata: docker.Image{
+		DockerImageMetadata: docker.Image{
 			ID: "abc123",
 		},
 	})
@@ -242,7 +242,7 @@ func TestEtcdCreateImage(t *testing.T) {
 		t.Errorf("Expected %v, got %v", e, a)
 	}
 
-	if e, a := "abc123", image.Metadata.ID; e != a {
+	if e, a := "abc123", image.DockerImageMetadata.ID; e != a {
 		t.Errorf("Expected %v, got %v", e, a)
 	}
 }

--- a/pkg/image/registry/imagerepositorymapping/rest.go
+++ b/pkg/image/registry/imagerepositorymapping/rest.go
@@ -67,11 +67,6 @@ func (s *REST) Create(ctx kapi.Context, obj runtime.Object) (<-chan apiserver.RE
 	// you should not do this, but we have a bug right now that prevents us from trusting the ctx passed in
 	imageRepoCtx := kapi.WithNamespace(kapi.NewContext(), repo.Namespace)
 
-	// the our docker image repository hook needs to be updated to send name, but I don't know where lives.  I'm wiring this through for now
-	if len(mapping.Image.Name) == 0 {
-		mapping.Image.Name = mapping.Image.ID
-	}
-
 	if errs := validation.ValidateImageRepositoryMapping(mapping); len(errs) > 0 {
 		return nil, errors.NewInvalid("imageRepositoryMapping", mapping.Name, errs)
 	}

--- a/pkg/image/registry/imagerepositorymapping/rest_test.go
+++ b/pkg/image/registry/imagerepositorymapping/rest_test.go
@@ -191,7 +191,7 @@ func TestCreateImageRepositoryMapping(t *testing.T) {
 				Name: "imageID1",
 			},
 			DockerImageReference: "localhost:5000/someproject/somerepo:imageID1",
-			Metadata: docker.Image{
+			DockerImageMetadata: docker.Image{
 				Config: &docker.Config{
 					Cmd:          []string{"ls", "/"},
 					Env:          []string{"a=1"},
@@ -219,7 +219,7 @@ func TestCreateImageRepositoryMapping(t *testing.T) {
 	if e, a := mapping.Image.DockerImageReference, image.DockerImageReference; e != a {
 		t.Errorf("Expected %s, got %s", e, a)
 	}
-	if !reflect.DeepEqual(mapping.Image.Metadata, image.Metadata) {
+	if !reflect.DeepEqual(mapping.Image.DockerImageMetadata, image.DockerImageMetadata) {
 		t.Errorf("Expected %#v, got %#v", mapping.Image, image)
 	}
 
@@ -257,7 +257,7 @@ func TestCreateImageRepositoryConflictingNamespace(t *testing.T) {
 				Name: "imageID1",
 			},
 			DockerImageReference: "localhost:5000/someproject/somerepo:imageID1",
-			Metadata: docker.Image{
+			DockerImageMetadata: docker.Image{
 				Config: &docker.Config{
 					Cmd:          []string{"ls", "/"},
 					Env:          []string{"a=1"},


### PR DESCRIPTION
Rename Image.Metadata to Image.DockerImageMetadata to avoid
serialization conflict with Kubernetes Metadata type.

Update Image and ImageRepositoryMapping to use Name instead of ID.

https://github.com/openshift/docker-registry-extensions/pull/1 depends on this.
