### PR TITLE
fix master thirdparty tests

### DIFF
--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/master/master_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/master/master_test.go
@@ -442,6 +442,8 @@ type FooList struct {
 func initThirdParty(t *testing.T, version string) (*tools.FakeEtcdClient, *httptest.Server, *assert.Assertions) {
 	master, _, assert := setUp(t)
 
+	os.Setenv("ETCD_PREFIX", "thirdparty")
+
 	api := &experimental.ThirdPartyResource{
 		ObjectMeta: api.ObjectMeta{
 			Name: "foo.company.com",


### PR DESCRIPTION
clean `make check`.  Not sure if this is the correct solution but the etcd patch prefix was `/` and so things were looking for keys like `//foo`