### PR TITLE
cmd tests: fix diagnostics tests

### DIFF
--- a/test/cmd/admin.sh
+++ b/test/cmd/admin.sh
@@ -301,7 +301,3 @@ os::cmd::expect_success_and_not_text "oc get rolebindings/cluster-admin         
 os::cmd::expect_success_and_not_text "oc get scc/restricted                     --output-version=v1 --template='{{.groups}}'"              'cascaded-group'
 echo "user-group-cascade: ok"
 
-
-os::cmd::expect_failure_and_text 'openshift ex diagnostics FakeDiagnostic AlsoMissing' 'No requested diagnostics are available: requested=FakeDiagnostic AlsoMissing'
-os::cmd::expect_failure_and_text 'openshift ex diagnostics AnalyzeLogs AlsoMissing' 'Not all requested diagnostics are available: missing=AlsoMissing requested=AnalyzeLogs AlsoMissing available='
-echo "diagnostics: ok"

--- a/test/cmd/diagnostics.sh
+++ b/test/cmd/diagnostics.sh
@@ -16,12 +16,14 @@ os::log::install_errexit
 # Without things feeding into systemd, AnalyzeLogs and UnitStatus are irrelevant.
 # The rest should be included in some fashion.
 
-os::cmd::expect_success 'openshift ex diagnostics -d ClusterRoleBindings,ClusterRoles,ConfigContexts '
+os::cmd::expect_success 'openshift ex diagnostics ClusterRoleBindings,ClusterRoles,ConfigContexts '
 # DiagnosticPod can't run without Docker, would just time out. Exercise flags instead.
-os::cmd::expect_success "openshift ex diagnostics -d DiagnosticPod --prevent-modification --images=foo"
-os::cmd::expect_success "openshift ex diagnostics -d MasterConfigCheck,NodeConfigCheck --master-config=${MASTER_CONFIG_DIR}/master-config.yaml --node-config=${NODE_CONFIG_DIR}/node-config.yaml"
-os::cmd::expect_success_and_text 'openshift ex diagnostics -d ClusterRegistry' "DClu1002 from diagnostic ClusterRegistry"
+os::cmd::expect_success "openshift ex diagnostics DiagnosticPod --prevent-modification --images=foo"
+os::cmd::expect_success "openshift ex diagnostics MasterConfigCheck,NodeConfigCheck --master-config=${MASTER_CONFIG_DIR}/master-config.yaml --node-config=${NODE_CONFIG_DIR}/node-config.yaml"
+os::cmd::expect_success_and_text 'openshift ex diagnostics ClusterRegistry' "DClu1002 from diagnostic ClusterRegistry"
 # ClusterRouter fails differently depending on whether other tests have run first, so don't test for specific error
-os::cmd::expect_failure 'openshift ex diagnostics -d ClusterRouter' # "DClu2001 from diagnostic ClusterRouter"
-os::cmd::expect_failure 'openshift ex diagnostics -d NodeDefinitions'
+os::cmd::expect_failure 'openshift ex diagnostics ClusterRouter' # "DClu2001 from diagnostic ClusterRouter"
+os::cmd::expect_failure 'openshift ex diagnostics NodeDefinitions'
+os::cmd::expect_failure_and_text 'openshift ex diagnostics FakeDiagnostic AlsoMissing' 'No requested diagnostics are available: requested=FakeDiagnostic AlsoMissing'
+os::cmd::expect_failure_and_text 'openshift ex diagnostics AnalyzeLogs AlsoMissing' 'Not all requested diagnostics are available: missing=AlsoMissing requested=AnalyzeLogs AlsoMissing available='
 echo "diagnostics: ok"


### PR DESCRIPTION
You'll need to adjust existing tests for the changed cmd syntax.