### PR TITLE
first pass cli fixes

### DIFF
--- a/pkg/oc/bootstrap/docker/openshift/import.go
+++ b/pkg/oc/bootstrap/docker/openshift/import.go
@@ -15,7 +15,7 @@ import (
 // ImportObjects imports objects into OpenShift from a particular location
 // into a given namespace
 func ImportObjects(f *clientcmd.Factory, ns, location string) error {
-	schema, err := f.Validator(false, false, "")
+	schema, err := f.Validator(false)
 	if err != nil {
 		return err
 	}
@@ -24,7 +24,7 @@ func ImportObjects(f *clientcmd.Factory, ns, location string) error {
 		return err
 	}
 	glog.V(8).Infof("Importing data:\n%s\n", string(data))
-	r := f.NewBuilder(true).
+	r := f.NewBuilder().
 		Schema(schema).
 		ContinueOnError().
 		NamespaceParam(ns).

--- a/pkg/oc/cli/cmd/export.go
+++ b/pkg/oc/cli/cmd/export.go
@@ -110,20 +110,11 @@ func RunExport(f *clientcmd.Factory, exporter Exporter, in io.Reader, out io.Wri
 		return err
 	}
 
-	builder, err := f.NewUnstructuredBuilder(true)
-	if err != nil {
-		return err
-	}
-
-	mapper, typer, err := f.UnstructuredObject()
-	if err != nil {
-		return err
-	}
-
-	b := builder.
+	b := f.NewBuilder().
+		Unstructured().
 		NamespaceParam(cmdNamespace).DefaultNamespace().AllNamespaces(allNamespaces).
 		FilenameParam(explicit, &resource.FilenameOptions{Recursive: false, Filenames: filenames}).
-		SelectorParam(selector).
+		LabelSelector(selector).
 		ResourceTypeOrNameArgs(true, args...).
 		Flatten()
 
@@ -189,7 +180,7 @@ func RunExport(f *clientcmd.Factory, exporter Exporter, in io.Reader, out io.Wri
 
 	var result runtime.Object
 	if len(asTemplate) > 0 {
-		objects, err := resource.AsVersionedObjects(infos, outputVersion, legacyscheme.Codecs.LegacyCodec(outputVersion))
+		objects, err := clientcmd.AsVersionedObjects(infos, outputVersion, legacyscheme.Codecs.LegacyCodec(outputVersion))
 		if err != nil {
 			return err
 		}
@@ -202,7 +193,7 @@ func RunExport(f *clientcmd.Factory, exporter Exporter, in io.Reader, out io.Wri
 			return err
 		}
 	} else {
-		object, err := resource.AsVersionedObject(infos, !one, outputVersion, legacyscheme.Codecs.LegacyCodec(outputVersion))
+		object, err := clientcmd.AsVersionedObject(infos, !one, outputVersion, legacyscheme.Codecs.LegacyCodec(outputVersion))
 		if err != nil {
 			return err
 		}
@@ -224,6 +215,7 @@ func RunExport(f *clientcmd.Factory, exporter Exporter, in io.Reader, out io.Wri
 	printOpts.OutputFormatArgument = templateFile
 	printOpts.AllowMissingKeys = kcmdutil.GetFlagBool(cmd, "allow-missing-template-keys")
 
+	mapper, typer := f.Object()
 	p, err := kprinters.GetStandardPrinter(
 		mapper, typer, legacyscheme.Codecs.LegacyCodec(outputVersion), decoders, *printOpts)
 

--- a/pkg/oc/cli/cmd/newapp.go
+++ b/pkg/oc/cli/cmd/newapp.go
@@ -166,17 +166,14 @@ func (o *ObjectGeneratorOptions) Complete(baseName, commandName string, f *clien
 	}
 
 	mapper, typer := f.Object()
-	dynamicMapper, dynamicTyper, err := f.UnstructuredObject()
-	if err != nil {
-		return err
-	}
+
 	// ignore errors.   We use this to make a best guess at preferred seralizations, but the command might run without a server
 	discoveryClient, _ := f.DiscoveryClient()
 
 	o.Action.Out, o.Action.ErrOut = out, o.ErrOut
 	o.Action.Bulk.DynamicMapper = &resource.Mapper{
-		RESTMapper:   dynamicMapper,
-		ObjectTyper:  dynamicTyper,
+		RESTMapper:   mapper,
+		ObjectTyper:  typer,
 		ClientMapper: resource.ClientMapperFunc(f.UnstructuredClientForMapping),
 	}
 	o.Action.Bulk.Mapper = &resource.Mapper{

--- a/pkg/oc/cli/cmd/set/env.go
+++ b/pkg/oc/cli/cmd/set/env.go
@@ -315,7 +315,7 @@ func (o *EnvOptions) RunEnv(f *clientcmd.Factory) error {
 	// Keep a copy of the original objects prior to updating their environment.
 	// Used in constructing the patch(es) that will be applied in the server.
 	gv := *clientConfig.GroupVersion
-	oldObjects, err := resource.AsVersionedObjects(infos, gv, legacyscheme.Codecs.LegacyCodec(gv))
+	oldObjects, err := clientcmd.AsVersionedObjects(infos, gv, legacyscheme.Codecs.LegacyCodec(gv))
 	if err != nil {
 		return err
 	}
@@ -447,7 +447,7 @@ func (o *EnvOptions) RunEnv(f *clientcmd.Factory) error {
 		return f.PrintResourceInfos(o.Cmd, o.Local, infos, o.Out)
 	}
 
-	objects, err := resource.AsVersionedObjects(infos, gv, legacyscheme.Codecs.LegacyCodec(gv))
+	objects, err := clientcmd.AsVersionedObjects(infos, gv, legacyscheme.Codecs.LegacyCodec(gv))
 	if err != nil {
 		return err
 	}

--- a/pkg/oc/cli/cmd/set/imagelookup.go
+++ b/pkg/oc/cli/cmd/set/imagelookup.go
@@ -267,7 +267,7 @@ func (o *ImageLookupOptions) Run() error {
 		return fmt.Errorf("%s/%s no changes", infos[0].Mapping.Resource, infos[0].Name)
 	}
 	if o.PrintObject != nil {
-		object, err := resource.AsVersionedObject(infos, !singleItemImplied, o.OutputVersion, legacyscheme.Codecs.LegacyCodec(o.OutputVersion))
+		object, err := clientcmd.AsVersionedObject(infos, !singleItemImplied, o.OutputVersion, legacyscheme.Codecs.LegacyCodec(o.OutputVersion))
 		if err != nil {
 			return err
 		}

--- a/pkg/oc/cli/cmd/set/volume.go
+++ b/pkg/oc/cli/cmd/set/volume.go
@@ -606,7 +606,7 @@ func setVolumeSourceByType(kv *kapi.Volume, opts *AddVolumeOptions) error {
 func (v *VolumeOptions) printVolumes(infos []*resource.Info) []error {
 	listingErrors := []error{}
 	for _, info := range infos {
-		_, err := v.UpdatePodSpecForObject(info.Object, func(spec *kapi.PodSpec) error {
+		_, err := v.UpdatePodSpecForObject(info.Object, func(spec *v1.PodSpec) error {
 			return v.listVolumeForSpec(spec, info)
 		})
 		if err != nil {

--- a/pkg/oc/cli/cmd/wrappers.go
+++ b/pkg/oc/cli/cmd/wrappers.go
@@ -15,6 +15,7 @@ import (
 	kcmd "k8s.io/kubernetes/pkg/kubectl/cmd"
 	kcmdauth "k8s.io/kubernetes/pkg/kubectl/cmd/auth"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/config"
+	"k8s.io/kubernetes/pkg/kubectl/cmd/resource"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 
@@ -67,7 +68,7 @@ var (
 
 // NewCmdGet is a wrapper for the Kubernetes cli get command
 func NewCmdGet(fullName string, f *clientcmd.Factory, out, errOut io.Writer) *cobra.Command {
-	cmd := kcmd.NewCmdGet(f, out, errOut)
+	cmd := resource.NewCmdGet(f, out, errOut)
 	cmd.Long = fmt.Sprintf(getLong, fullName)
 	cmd.Example = fmt.Sprintf(getExample, fullName)
 	cmd.SuggestFor = []string{"list"}

--- a/pkg/oc/cli/util/clientcmd/factory.go
+++ b/pkg/oc/cli/util/clientcmd/factory.go
@@ -91,7 +91,7 @@ func (f *Factory) PrintResourceInfos(cmd *cobra.Command, isLocal bool, infos []*
 	}
 
 	printAsList := len(infos) != 1
-	object, err := asVersionedObject(infos, printAsList, schema.GroupVersion{}, legacyscheme.Codecs.LegacyCodec())
+	object, err := AsVersionedObject(infos, printAsList, schema.GroupVersion{}, legacyscheme.Codecs.LegacyCodec())
 	if err != nil {
 		return err
 	}
@@ -99,12 +99,12 @@ func (f *Factory) PrintResourceInfos(cmd *cobra.Command, isLocal bool, infos []*
 	return printer.PrintObj(object, out)
 }
 
-// asVersionedObject converts a list of infos into a single object - either a List containing
+// AsVersionedObject converts a list of infos into a single object - either a List containing
 // the objects as children, or if only a single Object is present, as that object. The provided
 // version will be preferred as the conversion target, but the Object's mapping version will be
 // used if that version is not present.
-func asVersionedObject(infos []*resource.Info, forceList bool, version schema.GroupVersion, encoder runtime.Encoder) (runtime.Object, error) {
-	objects, err := asVersionedObjects(infos, version, encoder)
+func AsVersionedObject(infos []*resource.Info, forceList bool, version schema.GroupVersion, encoder runtime.Encoder) (runtime.Object, error) {
+	objects, err := AsVersionedObjects(infos, version, encoder)
 	if err != nil {
 		return nil, err
 	}
@@ -153,7 +153,7 @@ func tryConvert(converter runtime.ObjectConvertor, object runtime.Object, versio
 // AsVersionedObjects converts a list of infos into versioned objects. The provided
 // version will be preferred as the conversion target, but the Object's mapping version will be
 // used if that version is not present.
-func asVersionedObjects(infos []*resource.Info, version schema.GroupVersion, encoder runtime.Encoder) ([]runtime.Object, error) {
+func AsVersionedObjects(infos []*resource.Info, version schema.GroupVersion, encoder runtime.Encoder) ([]runtime.Object, error) {
 	objects := []runtime.Object{}
 	for _, info := range infos {
 		if info.Object == nil {

--- a/pkg/oc/experimental/config/patch.go
+++ b/pkg/oc/experimental/config/patch.go
@@ -136,11 +136,11 @@ func (o *PatchOptions) RunPatch() error {
 	}
 	info := infos[0]
 
-	originalObjJS, err := runtime.Encode(configapi.Codecs.LegacyCodec(info.Mapping.GroupVersionKind.GroupVersion()), info.VersionedObject.(runtime.Object))
+	originalObjJS, err := runtime.Encode(configapi.Codecs.LegacyCodec(info.Mapping.GroupVersionKind.GroupVersion()), info.Object.(runtime.Object))
 	if err != nil {
 		return err
 	}
-	patchedObj, err := configapi.Scheme.DeepCopy(info.VersionedObject)
+	patchedObj, err := configapi.Scheme.DeepCopy(info.Object)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Exports copied AsVersionedObject helpers and fixes calls to it.
`info.VersionedObject` was removed in https://github.com/kubernetes/kubernetes/pull/55660, updates usage to `info.Object`

cc @deads2k 