### PR TITLE
Deads2k/rebase19 conversion and tools fixes

### DIFF
--- a/pkg/oc/cli/util/clientcmd/factory.go
+++ b/pkg/oc/cli/util/clientcmd/factory.go
@@ -90,8 +90,13 @@ func (f *Factory) PrintResourceInfos(cmd *cobra.Command, isLocal bool, infos []*
 		return nil
 	}
 
+	clientConfig, err := f.ClientConfig()
+	if err != nil {
+		return err
+	}
+
 	printAsList := len(infos) != 1
-	object, err := AsVersionedObject(infos, printAsList, schema.GroupVersion{}, legacyscheme.Codecs.LegacyCodec())
+	object, err := AsVersionedObject(infos, printAsList, *clientConfig.GroupVersion, legacyscheme.Codecs.LegacyCodec())
 	if err != nil {
 		return err
 	}

--- a/tools/gendocs/gen_openshift_docs.go
+++ b/tools/gendocs/gen_openshift_docs.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"path/filepath"
 
+	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+
 	"github.com/openshift/origin/pkg/cmd/util/gendocs"
 	"github.com/openshift/origin/pkg/oc/cli"
 )
@@ -47,5 +49,7 @@ func main() {
 	outFile := outDir + "oc_by_example_content.adoc"
 	out := os.Stdout
 	cmd := cli.NewCommandCLI("oc", "oc", &bytes.Buffer{}, out, ioutil.Discard)
+	kcmdutil.AddPrinterFlags(cmd)
+
 	gendocs.GenDocs(cmd, outFile)
 }


### PR DESCRIPTION
Fixes `gendocs` panic
Fixes `clientcmd.Factory#PrintResourceInfos` internal to external object conversion

cc @deads2k 