### PR TITLE
fix convert no group

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/convert.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/convert.go
@@ -184,6 +184,10 @@ func (o *ConvertOptions) RunConvert() error {
 		return fmt.Errorf("no objects passed to convert")
 	}
 
+	if !infos[0].Mapping.GroupVersionKind.GroupVersion().Empty() {
+		o.outputVersion = infos[0].Mapping.GroupVersionKind.GroupVersion()
+	}
+
 	objects, err := asVersionedObject(infos, !singleItemImplied, o.outputVersion, o.encoder)
 	if err != nil {
 		return err
@@ -278,7 +282,12 @@ func asVersionedObjects(infos []*resource.Info, version schema.GroupVersion, enc
 				objects = append(objects, &runtime.Unknown{Raw: data})
 				continue
 			}
-			targetVersions = append(targetVersions, version)
+			gv := version
+			if !info.Mapping.GroupVersionKind.GroupVersion().Empty() {
+				gv = info.Mapping.GroupVersionKind.GroupVersion()
+			}
+
+			targetVersions = append(targetVersions, gv)
 		}
 
 		converted, err := tryConvert(info.Mapping.ObjectConvertor, info.Object, targetVersions...)


### PR DESCRIPTION
Fixes the conversion error seen in convert.sh:22
```
error: batch.Job is not suitable for converting to "v1"
```

Also fixes remaining failing convert.sh tests

cc @deads2k 