### PR TITLE
wire through a fallback mapper

### DIFF
--- a/vendor/k8s.io/kubernetes/cmd/kube-controller-manager/app/autoscaling.go
+++ b/vendor/k8s.io/kubernetes/cmd/kube-controller-manager/app/autoscaling.go
@@ -75,7 +75,7 @@ func startHPAControllerWithMetricsClient(ctx ControllerContext, metricsClient me
 	// TODO: we need something like deferred discovery REST mapper that calls invalidate
 	// on cache misses.
 	cachedDiscovery := discocache.NewMemCacheClient(hpaClientGoClient.Discovery())
-	restMapper := discovery.NewDeferredDiscoveryRESTMapper(cachedDiscovery, apimeta.InterfacesForUnstructured)
+	restMapper := discovery.NewDeferredDiscoveryRESTMapper(cachedDiscovery, apimeta.InterfacesForUnstructured, nil)
 	restMapper.Reset()
 	// we don't use cached discovery because DiscoveryScaleKindResolver does its own caching,
 	// so we want to re-fetch every time when we actually ask for it

--- a/vendor/k8s.io/kubernetes/cmd/kube-controller-manager/app/core.go
+++ b/vendor/k8s.io/kubernetes/cmd/kube-controller-manager/app/core.go
@@ -336,7 +336,7 @@ func startGarbageCollectorController(ctx ControllerContext) (bool, error) {
 
 	// Use a discovery client capable of being refreshed.
 	discoveryClient := cacheddiscovery.NewMemCacheClient(gcClientset.Discovery())
-	restMapper := discovery.NewDeferredDiscoveryRESTMapper(discoveryClient, meta.InterfacesForUnstructured)
+	restMapper := discovery.NewDeferredDiscoveryRESTMapper(discoveryClient, meta.InterfacesForUnstructured, nil)
 	restMapper.Reset()
 
 	config := ctx.ClientBuilder.ConfigOrDie("generic-garbage-collector")

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/util/factory_object_mapping.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/util/factory_object_mapping.go
@@ -77,11 +77,13 @@ func NewObjectMappingFactory(clientAccessFactory ClientAccessFactory) ObjectMapp
 // the built in mapper if necessary. It supports unstructured objects either way, since
 // the underlying Scheme supports Unstructured. The mapper will return converters that can
 // convert versioned types to unstructured and back.
+// It can return an error and the best effort unstructured mapper and typer.
 func (f *ring1Factory) objectLoader() (meta.RESTMapper, runtime.ObjectTyper, error) {
 	discoveryClient, err := f.clientAccessFactory.DiscoveryClient()
 	if err != nil {
-		glog.V(3).Infof("Unable to get a discovery client to find server resources, falling back to hardcoded types: %v", err)
-		return legacyscheme.Registry.RESTMapper(), legacyscheme.Scheme, nil
+		unstructuredMapper := discovery.NewRESTMapper(nil, meta.InterfacesForUnstructured)
+		unstructuredTyper := discovery.NewUnstructuredObjectTyper(nil)
+		return unstructuredMapper, unstructuredTyper, err
 	}
 
 	groupResources, err := discovery.GetAPIGroupResources(discoveryClient)
@@ -89,9 +91,11 @@ func (f *ring1Factory) objectLoader() (meta.RESTMapper, runtime.ObjectTyper, err
 		discoveryClient.Invalidate()
 		groupResources, err = discovery.GetAPIGroupResources(discoveryClient)
 	}
+	// even if we can't get all the results, we're better off continuing with what we can than not presenting
+	// anything.  This mirrors old behavior that used to fallback to a hardcoded list of API types compiled
+	// into kubernetes.
 	if err != nil {
-		glog.V(3).Infof("Unable to retrieve API resources, falling back to hardcoded types: %v", err)
-		return legacyscheme.Registry.RESTMapper(), legacyscheme.Scheme, nil
+		glog.V(1).Infof("Unable to retrieve all API resources, continuing with partial results: %v", err)
 	}
 
 	// allow conversion between typed and unstructured objects

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/util/factory_object_mapping.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/util/factory_object_mapping.go
@@ -100,11 +100,11 @@ func (f *ring1Factory) objectLoader() (meta.RESTMapper, runtime.ObjectTyper, err
 
 	// allow conversion between typed and unstructured objects
 	interfaces := meta.InterfacesForUnstructuredConversion(legacyscheme.Registry.InterfacesFor)
-	mapper := discovery.NewDeferredDiscoveryRESTMapper(discoveryClient, meta.VersionInterfacesFunc(interfaces))
+	mapper := discovery.NewDeferredDiscoveryRESTMapper(discoveryClient, meta.VersionInterfacesFunc(interfaces), legacyscheme.Registry.RESTMapper())
 	// TODO: should this also indicate it recognizes typed objects?
 	typer := discovery.NewUnstructuredObjectTyper(groupResources, legacyscheme.Scheme)
 	expander := NewShortcutExpander(mapper, discoveryClient)
-	return expander, typer, err
+	return expander, typer, nil
 }
 
 func (f *ring1Factory) Object() (meta.RESTMapper, runtime.ObjectTyper) {

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/client-go/discovery/restmapper.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/client-go/discovery/restmapper.go
@@ -177,10 +177,11 @@ type DeferredDiscoveryRESTMapper struct {
 // NewDeferredDiscoveryRESTMapper returns a
 // DeferredDiscoveryRESTMapper that will lazily query the provided
 // client for discovery information to do REST mappings.
-func NewDeferredDiscoveryRESTMapper(cl CachedDiscoveryInterface, versionInterface meta.VersionInterfacesFunc) *DeferredDiscoveryRESTMapper {
+func NewDeferredDiscoveryRESTMapper(cl CachedDiscoveryInterface, versionInterface meta.VersionInterfacesFunc, delegate meta.RESTMapper) *DeferredDiscoveryRESTMapper {
 	return &DeferredDiscoveryRESTMapper{
 		cl:               cl,
 		versionInterface: versionInterface,
+		delegate:         delegate,
 	}
 }
 

--- a/vendor/k8s.io/kubernetes/test/integration/etcd/BUILD
+++ b/vendor/k8s.io/kubernetes/test/integration/etcd/BUILD
@@ -22,7 +22,6 @@ go_test(
         "//cmd/kube-apiserver/app/options:go_default_library",
         "//pkg/api/legacyscheme:go_default_library",
         "//pkg/apis/core:go_default_library",
-        "//pkg/kubectl/cmd/util:go_default_library",
         "//pkg/master:go_default_library",
         "//test/integration/framework:go_default_library",
         "//vendor/github.com/coreos/etcd/clientv3:go_default_library",
@@ -40,8 +39,6 @@ go_test(
         "//vendor/k8s.io/apiserver/pkg/storage/storagebackend:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",
         "//vendor/k8s.io/client-go/rest:go_default_library",
-        "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",
-        "//vendor/k8s.io/client-go/tools/clientcmd/api:go_default_library",
         "//vendor/k8s.io/client-go/util/flowcontrol:go_default_library",
     ],
 )

--- a/vendor/k8s.io/kubernetes/test/integration/etcd/etcd_storage_path_test.go
+++ b/vendor/k8s.io/kubernetes/test/integration/etcd/etcd_storage_path_test.go
@@ -44,14 +44,11 @@ import (
 	"k8s.io/apiserver/pkg/storage/storagebackend"
 	clientset "k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
-	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/client-go/util/flowcontrol"
 	"k8s.io/kubernetes/cmd/kube-apiserver/app"
 	"k8s.io/kubernetes/cmd/kube-apiserver/app/options"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	kapi "k8s.io/kubernetes/pkg/apis/core"
-	"k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/test/integration/framework"
 
 	// install all APIs
@@ -798,9 +795,7 @@ func startRealMasterOrDie(t *testing.T, certDir string) (*allClient, clientv3.KV
 		t.Fatal(err)
 	}
 
-	mapper, _ := util.NewFactory(clientcmd.NewDefaultClientConfig(*clientcmdapi.NewConfig(), &clientcmd.ConfigOverrides{})).Object()
-
-	return client, kvClient, mapper
+	return client, kvClient, legacyscheme.Registry.RESTMapper()
 }
 
 func dumpEtcdKVOnFailure(t *testing.T, kvClient clientv3.KV) {

--- a/vendor/k8s.io/kubernetes/test/integration/garbagecollector/garbage_collector_test.go
+++ b/vendor/k8s.io/kubernetes/test/integration/garbagecollector/garbage_collector_test.go
@@ -219,7 +219,7 @@ func setupWithServer(t *testing.T, result *kubeapiservertesting.TestServer, work
 	createNamespaceOrDie("aval", clientSet, t)
 
 	discoveryClient := cacheddiscovery.NewMemCacheClient(clientSet.Discovery())
-	restMapper := discovery.NewDeferredDiscoveryRESTMapper(discoveryClient, meta.InterfacesForUnstructured)
+	restMapper := discovery.NewDeferredDiscoveryRESTMapper(discoveryClient, meta.InterfacesForUnstructured, nil)
 	restMapper.Reset()
 	deletableResources := garbagecollector.GetDeletableResources(discoveryClient)
 	config := *result.ClientConfig


### PR DESCRIPTION
I left the use of `.Internal()` resources in `cmd/process.go` (which currently succeeds / works as expected).
Attempted to use an unstructured mapper at first, but ended up with the following error:

```
$ oc process -f ./test/templates/testdata/guestbook.json --local -l app=guestbook -o yaml
error: failed to read input object (not a Template?): unable to recognize "./test/templates/testdata/guestbook.json": no matches for /, Kind=Template
```

Here is the patch that wires an unstructured mapper through instead (git-applies directly on top of this commit):
https://gist.github.com/juanvallejo/ae9b2e80113db01d728a87fc1e33802b

@deads2k 