### PR TITLE
use /tmp for osx cluster up

### DIFF
--- a/hack/build-local-images.py
+++ b/hack/build-local-images.py
@@ -58,6 +58,7 @@ image_config = {
         "directory": "origin",
         "binaries": {
             "openshift": "/usr/bin/openshift",
+            "oc": "/usr/bin/oc",
             "hyperkube": "/usr/bin/hyperkube"
         },
         "files": {}

--- a/install/etcd/etcd.yaml
+++ b/install/etcd/etcd.yaml
@@ -1,0 +1,36 @@
+kind: Pod
+apiVersion: v1
+metadata:
+  name: master-etcd
+  namespace: kube-system
+  labels:
+    openshift.io/control-plane: "true"
+    openshift.io/component: etcd
+spec:
+  restartPolicy: Always
+  hostNetwork: true
+  containers:
+  - name: etcd
+    image: openshift/origin:latest
+    workingDir: /var/lib/etcd
+    command: ["/bin/sh", "-c"]
+    args:
+    - |
+      #!/bin/sh
+      set -o allexport
+      exec openshift start etcd --config=/etc/origin/master/master-config.yaml
+    securityContext:
+      privileged: true
+    volumeMounts:
+     - mountPath: /etc/origin/master/
+       name: master-config
+       readOnly: true
+     - mountPath: /var/lib/etcd/
+       name: master-data
+  volumes:
+  - name: master-config
+    hostPath:
+      path: /path/to/master/config-dir
+  - name: master-data
+    hostPath:
+      path: /var/lib/etcd

--- a/install/kube-apiserver/apiserver.yaml
+++ b/install/kube-apiserver/apiserver.yaml
@@ -1,0 +1,48 @@
+kind: Pod
+apiVersion: v1
+metadata:
+  name: master-api
+  namespace: kube-system
+  labels:
+    openshift.io/control-plane: "true"
+    openshift.io/component: api
+spec:
+  restartPolicy: Always
+  hostNetwork: true
+  containers:
+  - name: api
+    image: openshift/origin:latest
+    command: ["/bin/bash", "-c"]
+    args:
+    - |
+      #!/bin/bash
+      set -euo pipefail
+      if [[ -f /etc/origin/master/master.env ]]; then
+        set -o allexport
+        source /etc/origin/master/master.env
+      fi
+      exec openshift start master api --config=/etc/origin/master/master-config.yaml
+    securityContext:
+      privileged: true
+    volumeMounts:
+     - mountPath: /etc/origin/master/
+       name: master-config
+     - mountPath: /etc/origin/cloudprovider/
+       name: master-cloud-provider
+     - mountPath: /var/lib/origin/
+       name: master-data
+    livenessProbe:
+      httpGet:
+        scheme: HTTPS
+        port: 8443
+        path: healthz
+  volumes:
+  - name: master-config
+    hostPath:
+      path: /path/to/master/config-dir
+  - name: master-cloud-provider
+    hostPath:
+      path: /etc/origin/cloudprovider
+  - name: master-data
+    hostPath:
+      path: /var/lib/origin

--- a/install/kube-controller-manager/kube-controller-manager.yaml
+++ b/install/kube-controller-manager/kube-controller-manager.yaml
@@ -1,0 +1,53 @@
+kind: Pod
+apiVersion: v1
+metadata:
+  name: kube-controller-manager
+  namespace: kube-system
+  labels:
+    openshift.io/control-plane: "true"
+    openshift.io/component: controllers
+spec:
+  restartPolicy: Always
+  hostNetwork: true
+  containers:
+  - name: controllers
+    image: openshift/origin:latest
+    command: ["hyperkube", "kube-controller-manager"]
+    args:
+    - "--enable-dynamic-provisioning=true"
+    - "--use-service-account-credentials=true"
+    - "--leader-elect-retry-period=3s"
+    - "--leader-elect-resource-lock=configmaps"
+    - "--controllers=*"
+    - "--controllers=-ttl"
+    - "--controllers=-bootstrapsigner"
+    - "--controllers=-tokencleaner"
+    - "--controllers=-horizontalpodautoscaling"
+    - "--pod-eviction-timeout=5m"
+    - "--cluster-signing-key-file="
+    - "--cluster-signing-cert-file="
+    - "--experimental-cluster-signing-duration=720h"
+    - "--root-ca-file=/etc/origin/master/ca-bundle.crt"
+    - "--port=10252"
+    - "--service-account-private-key-file=/etc/origin/master/serviceaccounts.private.key"
+    - "--kubeconfig=/etc/origin/master/openshift-master.kubeconfig"
+    - "--openshift-config=/etc/origin/master/master-config.yaml"
+    securityContext:
+      privileged: true
+    volumeMounts:
+     - mountPath: /etc/origin/master/
+       name: master-config
+     - mountPath: /etc/origin/cloudprovider/
+       name: master-cloud-provider
+    livenessProbe:
+      httpGet:
+        scheme: HTTP
+        port: 10252
+        path: healthz
+  volumes:
+  - name: master-config
+    hostPath:
+      path: /path/to/master/config-dir
+  - name: master-cloud-provider
+    hostPath:
+      path: /etc/origin/cloudprovider

--- a/install/kube-scheduler/kube-scheduler.yaml
+++ b/install/kube-scheduler/kube-scheduler.yaml
@@ -1,0 +1,40 @@
+kind: Pod
+apiVersion: v1
+metadata:
+  name: kube-scheduler
+  namespace: kube-system
+  labels:
+    openshift.io/control-plane: "true"
+    openshift.io/component: scheduler
+spec:
+  restartPolicy: Always
+  hostNetwork: true
+  containers:
+  - name: scheduler
+    image: openshift/origin:latest
+    command: ["hyperkube", "kube-scheduler"]
+    args:
+    - "--leader-elect=true"
+    - "--leader-elect-resource-lock=configmaps"
+    - "--port=10251"
+    - "--kubeconfig=/etc/origin/master/openshift-master.kubeconfig"
+    - "--policy-config-file="
+    securityContext:
+      privileged: true
+    volumeMounts:
+     - mountPath: /etc/origin/master/
+       name: master-config
+     - mountPath: /etc/origin/cloudprovider/
+       name: master-cloud-provider
+    livenessProbe:
+      httpGet:
+        scheme: HTTP
+        port: 10251
+        path: healthz
+  volumes:
+  - name: master-config
+    hostPath:
+      path: /path/to/master/config-dir
+  - name: master-cloud-provider
+    hostPath:
+      path: /etc/origin/cloudprovider

--- a/install/openshift-controller-manager/install.yaml
+++ b/install/openshift-controller-manager/install.yaml
@@ -1,0 +1,81 @@
+# the openshift controller manager can use a template because the openshift-apiserver will be available first
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: openshift-controller-manager
+parameters:
+- name: IMAGE
+  value: openshift/origin:latest
+- name: NAMESPACE
+  value: openshift-controller-manager
+- name: LOGLEVEL
+  value: "0"
+- name: MASTER_CONFIG_HOST_PATH
+- name: NODE_SELECTOR
+  value: "{}"
+objects:
+
+# to create the tsb server
+- apiVersion: apps/v1
+  kind: DaemonSet
+  metadata:
+    namespace: ${NAMESPACE}
+    name: openshift-controller-manager
+    labels:
+      openshift.io/control-plane: "true"
+      openshift.io/component: controllers
+  spec:
+    selector:
+      matchLabels:
+        openshift.io/control-plane: "true"
+        openshift.io/component: controllers
+    template:
+      metadata:
+        name: openshift-controller-manager
+        labels:
+          openshift.io/control-plane: "true"
+          openshift.io/component: controllers
+      spec:
+        serviceAccountName: openshift-controller-manager
+        restartPolicy: Always
+        hostNetwork: true
+        containers:
+        - name: c
+          image: ${IMAGE}
+          imagePullPolicy: IfNotPresent
+          command: ["openshift", "start", "master", "controllers"]
+          args:
+          - "--listen=https://0.0.0.0:8444"
+          - "--config=/etc/origin/master/master-config.yaml"
+          ports:
+          - containerPort: 8444
+          securityContext:
+            privileged: true
+            runAsUser: 0
+          volumeMounts:
+           - mountPath: /etc/origin/master/
+             name: master-config
+           - mountPath: /etc/origin/cloudprovider/
+             name: master-cloud-provider
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8444
+              scheme: HTTPS
+        # sensitive files still sit on disk for now
+        volumes:
+        - name: master-config
+          hostPath:
+            path: ${MASTER_CONFIG_HOST_PATH}
+        - name: master-cloud-provider
+          hostPath:
+            path: /etc/origin/cloudprovider
+
+
+# to be able to assign powers to the process
+- apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    namespace: ${NAMESPACE}
+    name: openshift-controller-manager
+

--- a/pkg/cmd/server/origin/controller/config.go
+++ b/pkg/cmd/server/origin/controller/config.go
@@ -1,20 +1,15 @@
 package controller
 
 import (
-	"fmt"
-	"io/ioutil"
 	"path"
 	"time"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/util/cert"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	kapi "k8s.io/kubernetes/pkg/apis/core"
-	kcontroller "k8s.io/kubernetes/pkg/controller"
 	serviceaccountadmission "k8s.io/kubernetes/plugin/pkg/admission/serviceaccount"
 
 	configapi "github.com/openshift/origin/pkg/cmd/server/apis/config"
-	"github.com/openshift/origin/pkg/cmd/server/crypto"
 	"github.com/openshift/origin/pkg/cmd/util/variable"
 )
 
@@ -56,8 +51,6 @@ func getOpenShiftClientEnvVars(options configapi.MasterConfig) ([]kapi.EnvVar, e
 // OpenshiftControllerConfig is the runtime (non-serializable) config object used to
 // launch the set of openshift (not kube) controllers.
 type OpenshiftControllerConfig struct {
-	ServiceAccountTokenControllerOptions ServiceAccountTokenControllerOptions
-
 	ServiceAccountControllerOptions ServiceAccountControllerOptions
 
 	BuildControllerConfig BuildControllerConfig
@@ -82,8 +75,6 @@ type OpenshiftControllerConfig struct {
 
 func (c *OpenshiftControllerConfig) GetControllerInitializers() (map[string]InitFunc, error) {
 	ret := map[string]InitFunc{}
-
-	ret["openshift.io/serviceaccount"] = c.ServiceAccountControllerOptions.RunController
 
 	ret["openshift.io/serviceaccount-pull-secrets"] = RunServiceAccountPullSecretsController
 	ret["openshift.io/origin-namespace"] = RunOriginNamespaceController
@@ -115,62 +106,9 @@ func (c *OpenshiftControllerConfig) GetControllerInitializers() (map[string]Init
 	return ret, nil
 }
 
-// NewOpenShiftControllerPreStartInitializers returns list of initializers for controllers
-// that needed to be run before any other controller is started.
-// Typically this has to done for the serviceaccount-token controller as it provides
-// tokens to other controllers.
-func (c *OpenshiftControllerConfig) ServiceAccountContentControllerInit() InitFunc {
-	return c.ServiceAccountTokenControllerOptions.RunController
-}
-
 func BuildOpenshiftControllerConfig(options configapi.MasterConfig) (*OpenshiftControllerConfig, error) {
 	var err error
 	ret := &OpenshiftControllerConfig{}
-
-	_, loopbackClientConfig, err := configapi.GetInternalKubeClient(options.MasterClients.OpenShiftLoopbackKubeConfig, options.MasterClients.OpenShiftLoopbackClientConnectionOverrides)
-	if err != nil {
-		return nil, err
-	}
-
-	ret.ServiceAccountTokenControllerOptions = ServiceAccountTokenControllerOptions{
-		RootClientBuilder: kcontroller.SimpleControllerClientBuilder{
-			ClientConfig: loopbackClientConfig,
-		},
-	}
-	if len(options.ServiceAccountConfig.PrivateKeyFile) > 0 {
-		ret.ServiceAccountTokenControllerOptions.PrivateKey, err = cert.PrivateKeyFromFile(options.ServiceAccountConfig.PrivateKeyFile)
-		if err != nil {
-			return nil, fmt.Errorf("error reading signing key for Service Account Token Manager: %v", err)
-		}
-	}
-	if len(options.ServiceAccountConfig.MasterCA) > 0 {
-		ret.ServiceAccountTokenControllerOptions.RootCA, err = ioutil.ReadFile(options.ServiceAccountConfig.MasterCA)
-		if err != nil {
-			return nil, fmt.Errorf("error reading master ca file for Service Account Token Manager: %s: %v", options.ServiceAccountConfig.MasterCA, err)
-		}
-		if _, err := cert.ParseCertsPEM(ret.ServiceAccountTokenControllerOptions.RootCA); err != nil {
-			return nil, fmt.Errorf("error parsing master ca file for Service Account Token Manager: %s: %v", options.ServiceAccountConfig.MasterCA, err)
-		}
-	}
-	if options.ControllerConfig.ServiceServingCert.Signer != nil && len(options.ControllerConfig.ServiceServingCert.Signer.CertFile) > 0 {
-		certFile := options.ControllerConfig.ServiceServingCert.Signer.CertFile
-		serviceServingCA, err := ioutil.ReadFile(certFile)
-		if err != nil {
-			return nil, fmt.Errorf("error reading ca file for Service Serving Certificate Signer: %s: %v", certFile, err)
-		}
-		if _, err := crypto.CertsFromPEM(serviceServingCA); err != nil {
-			return nil, fmt.Errorf("error parsing ca file for Service Serving Certificate Signer: %s: %v", certFile, err)
-		}
-
-		// if we have a rootCA bundle add that too.  The rootCA will be used when hitting the default master service, since those are signed
-		// using a different CA by default.  The rootCA's key is more closely guarded than ours and if it is compromised, that power could
-		// be used to change the trusted signers for every pod anyway, so we're already effectively trusting it.
-		if len(ret.ServiceAccountTokenControllerOptions.RootCA) > 0 {
-			ret.ServiceAccountTokenControllerOptions.ServiceServingCA = append(ret.ServiceAccountTokenControllerOptions.ServiceServingCA, ret.ServiceAccountTokenControllerOptions.RootCA...)
-			ret.ServiceAccountTokenControllerOptions.ServiceServingCA = append(ret.ServiceAccountTokenControllerOptions.ServiceServingCA, []byte("\n")...)
-		}
-		ret.ServiceAccountTokenControllerOptions.ServiceServingCA = append(ret.ServiceAccountTokenControllerOptions.ServiceServingCA, serviceServingCA...)
-	}
 
 	ret.ServiceAccountControllerOptions = ServiceAccountControllerOptions{
 		ManagedNames: options.ServiceAccountConfig.ManagedNames,

--- a/pkg/cmd/server/origin/controller/serviceaccount.go
+++ b/pkg/cmd/server/origin/controller/serviceaccount.go
@@ -4,9 +4,7 @@ import (
 	"github.com/golang/glog"
 
 	kapiv1 "k8s.io/api/core/v1"
-	"k8s.io/kubernetes/pkg/controller"
 	sacontroller "k8s.io/kubernetes/pkg/controller/serviceaccount"
-	"k8s.io/kubernetes/pkg/serviceaccount"
 
 	"github.com/openshift/origin/pkg/cmd/server/bootstrappolicy"
 	serviceaccountcontrollers "github.com/openshift/origin/pkg/serviceaccounts/controllers"
@@ -46,37 +44,6 @@ func (c *ServiceAccountControllerOptions) RunController(ctx ControllerContext) (
 	}
 	go controller.Run(3, ctx.Stop)
 
-	return true, nil
-}
-
-type ServiceAccountTokenControllerOptions struct {
-	RootCA           []byte
-	ServiceServingCA []byte
-	PrivateKey       interface{}
-
-	RootClientBuilder controller.SimpleControllerClientBuilder
-}
-
-func (c *ServiceAccountTokenControllerOptions) RunController(ctx ControllerContext) (bool, error) {
-	if c.PrivateKey == nil {
-		glog.Infof("Skipped starting Service Account Token Manager, no private key specified")
-		return false, nil
-	}
-
-	controller, err := sacontroller.NewTokensController(
-		ctx.ExternalKubeInformers.Core().V1().ServiceAccounts(),
-		ctx.ExternalKubeInformers.Core().V1().Secrets(),
-		c.RootClientBuilder.ClientOrDie(bootstrappolicy.InfraServiceAccountTokensControllerServiceAccountName),
-		sacontroller.TokensControllerOptions{
-			TokenGenerator:   serviceaccount.JWTTokenGenerator(c.PrivateKey),
-			RootCA:           c.RootCA,
-			ServiceServingCA: c.ServiceServingCA,
-		},
-	)
-	if err != nil {
-		return true, nil
-	}
-	go controller.Run(int(ctx.OpenshiftControllerOptions.ServiceAccountTokenOptions.ConcurrentSyncs), ctx.Stop)
 	return true, nil
 }
 

--- a/pkg/cmd/server/start/start_kube_controller_manager.go
+++ b/pkg/cmd/server/start/start_kube_controller_manager.go
@@ -21,8 +21,6 @@ func computeKubeControllerManagerArgs(kubeconfigFile, saPrivateKeyFile, saRootCA
 			"-tokencleaner",
 			// we have to configure this separately until it is generic
 			"-horizontalpodautoscaling",
-			// we carry patches on this. For now....
-			"-serviceaccount-token",
 		}
 	}
 	if _, ok := cmdLineArgs["service-account-private-key-file"]; !ok {

--- a/pkg/oc/bootstrap/bindata.go
+++ b/pkg/oc/bootstrap/bindata.go
@@ -36,6 +36,11 @@
 // examples/heapster/heapster-standalone.yaml
 // examples/prometheus/prometheus.yaml
 // examples/service-catalog/service-catalog.yaml
+// install/etcd/etcd.yaml
+// install/kube-apiserver/apiserver.yaml
+// install/kube-controller-manager/kube-controller-manager.yaml
+// install/kube-scheduler/kube-scheduler.yaml
+// install/openshift-controller-manager/install.yaml
 // install/origin-web-console/console-config.yaml
 // install/origin-web-console/console-template.yaml
 // install/origin-web-console/rbac-template.yaml
@@ -14947,6 +14952,345 @@ func examplesServiceCatalogServiceCatalogYaml() (*asset, error) {
 	return a, nil
 }
 
+var _installEtcdEtcdYaml = []byte(`kind: Pod
+apiVersion: v1
+metadata:
+  name: master-etcd
+  namespace: kube-system
+  labels:
+    openshift.io/control-plane: "true"
+    openshift.io/component: etcd
+spec:
+  restartPolicy: Always
+  hostNetwork: true
+  containers:
+  - name: etcd
+    image: openshift/origin:latest
+    workingDir: /var/lib/etcd
+    command: ["/bin/sh", "-c"]
+    args:
+    - |
+      #!/bin/sh
+      set -o allexport
+      exec openshift start etcd --config=/etc/origin/master/master-config.yaml
+    securityContext:
+      privileged: true
+    volumeMounts:
+     - mountPath: /etc/origin/master/
+       name: master-config
+       readOnly: true
+     - mountPath: /var/lib/etcd/
+       name: master-data
+  volumes:
+  - name: master-config
+    hostPath:
+      path: /path/to/master/config-dir
+  - name: master-data
+    hostPath:
+      path: /var/lib/etcd`)
+
+func installEtcdEtcdYamlBytes() ([]byte, error) {
+	return _installEtcdEtcdYaml, nil
+}
+
+func installEtcdEtcdYaml() (*asset, error) {
+	bytes, err := installEtcdEtcdYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "install/etcd/etcd.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _installKubeApiserverApiserverYaml = []byte(`kind: Pod
+apiVersion: v1
+metadata:
+  name: master-api
+  namespace: kube-system
+  labels:
+    openshift.io/control-plane: "true"
+    openshift.io/component: api
+spec:
+  restartPolicy: Always
+  hostNetwork: true
+  containers:
+  - name: api
+    image: openshift/origin:latest
+    command: ["/bin/bash", "-c"]
+    args:
+    - |
+      #!/bin/bash
+      set -euo pipefail
+      if [[ -f /etc/origin/master/master.env ]]; then
+        set -o allexport
+        source /etc/origin/master/master.env
+      fi
+      exec openshift start master api --config=/etc/origin/master/master-config.yaml
+    securityContext:
+      privileged: true
+    volumeMounts:
+     - mountPath: /etc/origin/master/
+       name: master-config
+     - mountPath: /etc/origin/cloudprovider/
+       name: master-cloud-provider
+     - mountPath: /var/lib/origin/
+       name: master-data
+    livenessProbe:
+      httpGet:
+        scheme: HTTPS
+        port: 8443
+        path: healthz
+  volumes:
+  - name: master-config
+    hostPath:
+      path: /path/to/master/config-dir
+  - name: master-cloud-provider
+    hostPath:
+      path: /etc/origin/cloudprovider
+  - name: master-data
+    hostPath:
+      path: /var/lib/origin`)
+
+func installKubeApiserverApiserverYamlBytes() ([]byte, error) {
+	return _installKubeApiserverApiserverYaml, nil
+}
+
+func installKubeApiserverApiserverYaml() (*asset, error) {
+	bytes, err := installKubeApiserverApiserverYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "install/kube-apiserver/apiserver.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _installKubeControllerManagerKubeControllerManagerYaml = []byte(`kind: Pod
+apiVersion: v1
+metadata:
+  name: kube-controller-manager
+  namespace: kube-system
+  labels:
+    openshift.io/control-plane: "true"
+    openshift.io/component: controllers
+spec:
+  restartPolicy: Always
+  hostNetwork: true
+  containers:
+  - name: controllers
+    image: openshift/origin:latest
+    command: ["hyperkube", "kube-controller-manager"]
+    args:
+    - "--enable-dynamic-provisioning=true"
+    - "--use-service-account-credentials=true"
+    - "--leader-elect-retry-period=3s"
+    - "--leader-elect-resource-lock=configmaps"
+    - "--controllers=*"
+    - "--controllers=-ttl"
+    - "--controllers=-bootstrapsigner"
+    - "--controllers=-tokencleaner"
+    - "--controllers=-horizontalpodautoscaling"
+    - "--pod-eviction-timeout=5m"
+    - "--cluster-signing-key-file="
+    - "--cluster-signing-cert-file="
+    - "--experimental-cluster-signing-duration=720h"
+    - "--root-ca-file=/etc/origin/master/ca-bundle.crt"
+    - "--port=10252"
+    - "--service-account-private-key-file=/etc/origin/master/serviceaccounts.private.key"
+    - "--kubeconfig=/etc/origin/master/openshift-master.kubeconfig"
+    - "--openshift-config=/etc/origin/master/master-config.yaml"
+    securityContext:
+      privileged: true
+    volumeMounts:
+     - mountPath: /etc/origin/master/
+       name: master-config
+     - mountPath: /etc/origin/cloudprovider/
+       name: master-cloud-provider
+    livenessProbe:
+      httpGet:
+        scheme: HTTP
+        port: 10252
+        path: healthz
+  volumes:
+  - name: master-config
+    hostPath:
+      path: /path/to/master/config-dir
+  - name: master-cloud-provider
+    hostPath:
+      path: /etc/origin/cloudprovider`)
+
+func installKubeControllerManagerKubeControllerManagerYamlBytes() ([]byte, error) {
+	return _installKubeControllerManagerKubeControllerManagerYaml, nil
+}
+
+func installKubeControllerManagerKubeControllerManagerYaml() (*asset, error) {
+	bytes, err := installKubeControllerManagerKubeControllerManagerYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "install/kube-controller-manager/kube-controller-manager.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _installKubeSchedulerKubeSchedulerYaml = []byte(`kind: Pod
+apiVersion: v1
+metadata:
+  name: kube-scheduler
+  namespace: kube-system
+  labels:
+    openshift.io/control-plane: "true"
+    openshift.io/component: scheduler
+spec:
+  restartPolicy: Always
+  hostNetwork: true
+  containers:
+  - name: scheduler
+    image: openshift/origin:latest
+    command: ["hyperkube", "kube-scheduler"]
+    args:
+    - "--leader-elect=true"
+    - "--leader-elect-resource-lock=configmaps"
+    - "--port=10251"
+    - "--kubeconfig=/etc/origin/master/openshift-master.kubeconfig"
+    - "--policy-config-file="
+    securityContext:
+      privileged: true
+    volumeMounts:
+     - mountPath: /etc/origin/master/
+       name: master-config
+     - mountPath: /etc/origin/cloudprovider/
+       name: master-cloud-provider
+    livenessProbe:
+      httpGet:
+        scheme: HTTP
+        port: 10251
+        path: healthz
+  volumes:
+  - name: master-config
+    hostPath:
+      path: /path/to/master/config-dir
+  - name: master-cloud-provider
+    hostPath:
+      path: /etc/origin/cloudprovider`)
+
+func installKubeSchedulerKubeSchedulerYamlBytes() ([]byte, error) {
+	return _installKubeSchedulerKubeSchedulerYaml, nil
+}
+
+func installKubeSchedulerKubeSchedulerYaml() (*asset, error) {
+	bytes, err := installKubeSchedulerKubeSchedulerYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "install/kube-scheduler/kube-scheduler.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _installOpenshiftControllerManagerInstallYaml = []byte(`# the openshift controller manager can use a template because the openshift-apiserver will be available first
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: openshift-controller-manager
+parameters:
+- name: IMAGE
+  value: openshift/origin:latest
+- name: NAMESPACE
+  value: openshift-controller-manager
+- name: LOGLEVEL
+  value: "0"
+- name: MASTER_CONFIG_HOST_PATH
+- name: NODE_SELECTOR
+  value: "{}"
+objects:
+
+# to create the tsb server
+- apiVersion: apps/v1
+  kind: DaemonSet
+  metadata:
+    namespace: ${NAMESPACE}
+    name: openshift-controller-manager
+    labels:
+      openshift.io/control-plane: "true"
+      openshift.io/component: controllers
+  spec:
+    selector:
+      matchLabels:
+        openshift.io/control-plane: "true"
+        openshift.io/component: controllers
+    template:
+      metadata:
+        name: openshift-controller-manager
+        labels:
+          openshift.io/control-plane: "true"
+          openshift.io/component: controllers
+      spec:
+        serviceAccountName: openshift-controller-manager
+        restartPolicy: Always
+        hostNetwork: true
+        containers:
+        - name: c
+          image: ${IMAGE}
+          imagePullPolicy: IfNotPresent
+          command: ["openshift", "start", "master", "controllers"]
+          args:
+          - "--listen=https://0.0.0.0:8444"
+          - "--config=/etc/origin/master/master-config.yaml"
+          ports:
+          - containerPort: 8444
+          securityContext:
+            privileged: true
+            runAsUser: 0
+          volumeMounts:
+           - mountPath: /etc/origin/master/
+             name: master-config
+           - mountPath: /etc/origin/cloudprovider/
+             name: master-cloud-provider
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8444
+              scheme: HTTPS
+        # sensitive files still sit on disk for now
+        volumes:
+        - name: master-config
+          hostPath:
+            path: ${MASTER_CONFIG_HOST_PATH}
+        - name: master-cloud-provider
+          hostPath:
+            path: /etc/origin/cloudprovider
+
+
+# to be able to assign powers to the process
+- apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    namespace: ${NAMESPACE}
+    name: openshift-controller-manager
+
+`)
+
+func installOpenshiftControllerManagerInstallYamlBytes() ([]byte, error) {
+	return _installOpenshiftControllerManagerInstallYaml, nil
+}
+
+func installOpenshiftControllerManagerInstallYaml() (*asset, error) {
+	bytes, err := installOpenshiftControllerManagerInstallYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "install/openshift-controller-manager/install.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 var _installOriginWebConsoleConsoleConfigYaml = []byte(`apiVersion: webconsole.config.openshift.io/v1
 kind: WebConsoleConfiguration
 clusterInfo:
@@ -15769,6 +16113,11 @@ var _bindata = map[string]func() (*asset, error){
 	"examples/heapster/heapster-standalone.yaml": examplesHeapsterHeapsterStandaloneYaml,
 	"examples/prometheus/prometheus.yaml": examplesPrometheusPrometheusYaml,
 	"examples/service-catalog/service-catalog.yaml": examplesServiceCatalogServiceCatalogYaml,
+	"install/etcd/etcd.yaml": installEtcdEtcdYaml,
+	"install/kube-apiserver/apiserver.yaml": installKubeApiserverApiserverYaml,
+	"install/kube-controller-manager/kube-controller-manager.yaml": installKubeControllerManagerKubeControllerManagerYaml,
+	"install/kube-scheduler/kube-scheduler.yaml": installKubeSchedulerKubeSchedulerYaml,
+	"install/openshift-controller-manager/install.yaml": installOpenshiftControllerManagerInstallYaml,
 	"install/origin-web-console/console-config.yaml": installOriginWebConsoleConsoleConfigYaml,
 	"install/origin-web-console/console-template.yaml": installOriginWebConsoleConsoleTemplateYaml,
 	"install/origin-web-console/rbac-template.yaml": installOriginWebConsoleRbacTemplateYaml,
@@ -15877,6 +16226,21 @@ var _bintree = &bintree{nil, map[string]*bintree{
 		}},
 	}},
 	"install": &bintree{nil, map[string]*bintree{
+		"etcd": &bintree{nil, map[string]*bintree{
+			"etcd.yaml": &bintree{installEtcdEtcdYaml, map[string]*bintree{}},
+		}},
+		"kube-apiserver": &bintree{nil, map[string]*bintree{
+			"apiserver.yaml": &bintree{installKubeApiserverApiserverYaml, map[string]*bintree{}},
+		}},
+		"kube-controller-manager": &bintree{nil, map[string]*bintree{
+			"kube-controller-manager.yaml": &bintree{installKubeControllerManagerKubeControllerManagerYaml, map[string]*bintree{}},
+		}},
+		"kube-scheduler": &bintree{nil, map[string]*bintree{
+			"kube-scheduler.yaml": &bintree{installKubeSchedulerKubeSchedulerYaml, map[string]*bintree{}},
+		}},
+		"openshift-controller-manager": &bintree{nil, map[string]*bintree{
+			"install.yaml": &bintree{installOpenshiftControllerManagerInstallYaml, map[string]*bintree{}},
+		}},
 		"origin-web-console": &bintree{nil, map[string]*bintree{
 			"console-config.yaml": &bintree{installOriginWebConsoleConsoleConfigYaml, map[string]*bintree{}},
 			"console-template.yaml": &bintree{installOriginWebConsoleConsoleTemplateYaml, map[string]*bintree{}},

--- a/pkg/oc/bootstrap/clusterup/kubeapiserver/config.go
+++ b/pkg/oc/bootstrap/clusterup/kubeapiserver/config.go
@@ -1,0 +1,70 @@
+package kubeapiserver
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path"
+
+	"github.com/golang/glog"
+	"github.com/openshift/origin/pkg/oc/bootstrap/docker/dockerhelper"
+	"github.com/openshift/origin/pkg/oc/bootstrap/docker/run"
+	"github.com/openshift/origin/pkg/oc/errors"
+)
+
+type KubeAPIServerStartConfig struct {
+	// MasterImage is the docker image for openshift start master
+	MasterImage string
+	ImageFormat string
+	DNSPort     int
+	PublicHost  string
+}
+
+func NewKubeAPIServerStartConfig() *KubeAPIServerStartConfig {
+	return &KubeAPIServerStartConfig{}
+
+}
+
+// Start starts the OpenShift master as a Docker container
+// and returns a directory in the local file system where
+// the OpenShift configuration has been copied
+func (opt KubeAPIServerStartConfig) MakeMasterConfig(dockerClient dockerhelper.Interface, imageRunHelper *run.Runner, out io.Writer) (string, error) {
+	tempDir, err := ioutil.TempDir("", "oc-cluster-up-kube-apiserver-")
+	if err != nil {
+		return "", err
+	}
+	// TODO eliminate the linkage that other tasks have on this particular structure
+	masterDir := path.Join(tempDir, "master")
+	if err := os.Mkdir(masterDir, 0755); err != nil {
+		return "", err
+	}
+
+	fmt.Fprintf(out, "Creating initial OpenShift master configuration\n")
+	createConfigCmd := []string{
+		"start", "master",
+		"--write-config=/var/lib/origin/openshift.local.config",
+		"--master=127.0.0.1",
+		fmt.Sprintf("--images=%s", opt.ImageFormat),
+		fmt.Sprintf("--dns=0.0.0.0:%d", opt.DNSPort),
+		fmt.Sprintf("--public-master=https://%s:8443", opt.PublicHost),
+	}
+	containerId, _, err := imageRunHelper.Image(opt.MasterImage).
+		Privileged().
+		HostNetwork().
+		HostPid().
+		Command(createConfigCmd...).Run()
+	if err != nil {
+		return "", errors.NewError("could not create OpenShift configuration: %v", err).WithCause(err)
+	}
+
+	glog.V(1).Infof("Copying OpenShift config to local directory %s", tempDir)
+	if err = dockerhelper.DownloadDirFromContainer(dockerClient, containerId, "/var/lib/origin/openshift.local.config", masterDir); err != nil {
+		if removeErr := os.RemoveAll(tempDir); removeErr != nil {
+			glog.V(2).Infof("Error removing temporary config dir %s: %v", tempDir, removeErr)
+		}
+		return "", err
+	}
+
+	return masterDir, nil
+}

--- a/pkg/oc/bootstrap/clusterup/kubelet/config.go
+++ b/pkg/oc/bootstrap/clusterup/kubelet/config.go
@@ -1,0 +1,59 @@
+package kubelet
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+
+	"github.com/openshift/origin/pkg/oc/bootstrap/docker/run"
+	"github.com/openshift/origin/pkg/oc/errors"
+)
+
+type NodeStartConfig struct {
+	// ContainerBinds is a list of local/path:image/path pairs
+	ContainerBinds []string
+	// NodeImage is the docker image for openshift start node
+	NodeImage string
+
+	Args []string
+}
+
+func NewNodeStartConfig() *NodeStartConfig {
+	return &NodeStartConfig{
+		ContainerBinds: []string{},
+	}
+
+}
+
+// Start starts the OpenShift master as a Docker container
+// and returns a directory in the local file system where
+// the OpenShift configuration has been copied
+func (opt NodeStartConfig) MakeNodeConfig(imageRunHelper *run.Runner, out io.Writer) (string, error) {
+	tempDir, err := ioutil.TempDir("", "oc-cluster-up-control-plane-node-")
+	if err != nil {
+		return "", err
+	}
+
+	binds := append(opt.ContainerBinds, fmt.Sprintf("%s:/var/lib/origin/openshift.local.config:z", tempDir))
+
+	fmt.Fprintf(out, "Creating initial OpenShift node configuration\n")
+	createConfigCmd := []string{
+		"adm", "create-node-config",
+		fmt.Sprintf("--node-dir=%s", "/var/lib/origin/openshift.local.config"),
+	}
+	createConfigCmd = append(createConfigCmd, opt.Args...)
+
+	_, _, err = imageRunHelper.Image(opt.NodeImage).
+		Privileged().
+		DiscardContainer().
+		HostNetwork().
+		HostPid().
+		Bind(binds...).
+		Entrypoint("oc").
+		Command(createConfigCmd...).Run()
+	if err != nil {
+		return "", errors.NewError("could not create OpenShift configuration: %v", err).WithCause(err)
+	}
+
+	return tempDir, nil
+}

--- a/pkg/oc/bootstrap/clusterup/kubelet/flags.go
+++ b/pkg/oc/bootstrap/clusterup/kubelet/flags.go
@@ -1,0 +1,56 @@
+package kubelet
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/openshift/origin/pkg/oc/bootstrap/docker/run"
+	"github.com/openshift/origin/pkg/oc/errors"
+)
+
+type KubeletStartFlags struct {
+	// ContainerBinds is a list of local/path:image/path pairs
+	ContainerBinds []string
+	// NodeImage is the docker image for openshift start node
+	NodeImage       string
+	Environment     []string
+	UseSharedVolume bool
+}
+
+func NewKubeletStartFlags() *KubeletStartFlags {
+	return &KubeletStartFlags{}
+
+}
+
+// Start starts the OpenShift master as a Docker container
+// and returns a directory in the local file system where
+// the OpenShift configuration has been copied
+func (opt KubeletStartFlags) MakeKubeletFlags(imageRunHelper *run.Runner, out io.Writer) (string, error) {
+	binds := append(opt.ContainerBinds)
+	env := append(opt.Environment)
+	if opt.UseSharedVolume {
+		env = append(env, "OPENSHIFT_CONTAINERIZED=false")
+	}
+
+	fmt.Fprintf(out, "Creating initial OpenShift node configuration\n")
+	createFlagsCmd := []string{
+		"start", "node",
+		"--write-flags",
+		"--config=/var/lib/origin/openshift.local.config/node/node-config.yaml",
+	}
+
+	_, stdout, _, _, err := imageRunHelper.Image(opt.NodeImage).
+		Privileged().
+		DiscardContainer().
+		HostNetwork().
+		HostPid().
+		Bind(binds...).
+		Env(env...).
+		Entrypoint("openshift").
+		Command(createFlagsCmd...).Output()
+	if err != nil {
+		return "", errors.NewError("could not create OpenShift configuration: %v", err).WithCause(err)
+	}
+
+	return stdout, nil
+}

--- a/pkg/oc/bootstrap/clusterup/kubelet/run_kubelet.go
+++ b/pkg/oc/bootstrap/clusterup/kubelet/run_kubelet.go
@@ -1,0 +1,92 @@
+package kubelet
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/openshift/origin/pkg/oc/bootstrap/docker/run"
+	"github.com/openshift/origin/pkg/oc/errors"
+)
+
+type KubeletRunConfig struct {
+	// ContainerBinds is a list of local/path:image/path pairs
+	ContainerBinds []string
+	// NodeImage is the docker image for openshift start node
+	NodeImage       string
+	Environment     []string
+	DockerRoot      string
+	UseSharedVolume bool
+	HostVolumesDir  string
+
+	HTTPProxy  string
+	HTTPSProxy string
+	NoProxy    []string
+
+	Args []string
+}
+
+func NewKubeletRunConfig() *KubeletRunConfig {
+	return &KubeletRunConfig{
+		ContainerBinds: []string{
+			"/var/log:/var/log:rw",
+			"/var/run:/var/run:rw",
+			"/sys:/sys:rw",
+			"/sys/fs/cgroup:/sys/fs/cgroup:rw",
+			"/dev:/dev",
+		},
+	}
+
+}
+
+// Start starts the OpenShift master as a Docker container
+// and returns a directory in the local file system where
+// the OpenShift configuration has been copied
+func (opt KubeletRunConfig) MakeNodeConfig(imageRunHelper *run.Runner, out io.Writer) (string, error) {
+	binds := append(opt.ContainerBinds)
+	env := []string{}
+	if len(opt.HTTPProxy) > 0 {
+		env = append(env, fmt.Sprintf("HTTP_PROXY=%s", opt.HTTPProxy))
+	}
+	if len(opt.HTTPSProxy) > 0 {
+		env = append(env, fmt.Sprintf("HTTPS_PROXY=%s", opt.HTTPSProxy))
+	}
+	if len(opt.NoProxy) > 0 {
+		env = append(env, fmt.Sprintf("NO_PROXY=%s", strings.Join(opt.NoProxy, ",")))
+	}
+	if opt.UseSharedVolume {
+		binds = append(binds, fmt.Sprintf("%[1]s:%[1]s:shared", opt.HostVolumesDir))
+		env = append(env, "OPENSHIFT_CONTAINERIZED=false")
+	} else {
+		binds = append(binds, "/:/rootfs:ro")
+		binds = append(binds, fmt.Sprintf("%[1]s:%[1]s:rslave", opt.HostVolumesDir))
+	}
+	env = append(env, opt.Environment...)
+	binds = append(binds, fmt.Sprintf("%[1]s:%[1]s", opt.DockerRoot))
+
+	// Kubelet needs to be able to write to
+	// /sys/devices/virtual/net/vethXXX/brport/hairpin_mode, so make this rw, not ro.
+	binds = append(binds, "/sys/devices/virtual/net:/sys/devices/virtual/net:rw")
+
+	fmt.Fprintf(out, "Running kubelet\n")
+	createConfigCmd := []string{
+		"kubelet",
+	}
+	createConfigCmd = append(createConfigCmd, opt.Args...)
+
+	_, err := imageRunHelper.Image(opt.NodeImage).
+		Name("origin"). // TODO figure out why the rest of cluster-up relies on this name
+		Privileged().
+		DiscardContainer().
+		HostNetwork().
+		HostPid().
+		Bind(binds...).
+		Env(env...).
+		Entrypoint("hyperkube").
+		Command(createConfigCmd...).Start()
+	if err != nil {
+		return "", errors.NewError("could not create OpenShift configuration: %v", err).WithCause(err)
+	}
+
+	return "", nil
+}

--- a/pkg/oc/bootstrap/clusterup/staticpods/load.go
+++ b/pkg/oc/bootstrap/clusterup/staticpods/load.go
@@ -1,0 +1,30 @@
+package staticpods
+
+import (
+	"io/ioutil"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/openshift/origin/pkg/oc/bootstrap"
+)
+
+func substitute(in string, replacements map[string]string) string {
+	curr := in
+	for oldVal, newVal := range replacements {
+		curr = strings.Replace(curr, oldVal, newVal, -1)
+	}
+
+	return curr
+}
+
+func UpsertStaticPod(sourceLocation string, replacements map[string]string, kubeletStaticPodDir string) error {
+	data, err := bootstrap.Asset(sourceLocation)
+	if err != nil {
+		return err
+	}
+
+	content := substitute(string(data), replacements)
+	fullLockubeletStaticPodDir := path.Join(kubeletStaticPodDir, filepath.Base(sourceLocation))
+	return ioutil.WriteFile(fullLockubeletStaticPodDir, []byte(content), 0644)
+}

--- a/pkg/oc/bootstrap/docker/host/host.go
+++ b/pkg/oc/bootstrap/docker/host/host.go
@@ -60,7 +60,7 @@ func NewHostHelper(dockerHelper *dockerhelper.Helper, image, volumesDir, configD
 
 // CanUseNsenterMounter returns true if the Docker host machine can execute findmnt through nsenter
 func (h *HostHelper) CanUseNsenterMounter() (bool, error) {
-	rc, err := h.runner().
+	_, rc, err := h.runner().
 		Image(h.image).
 		DiscardContainer().
 		Privileged().
@@ -74,7 +74,7 @@ func (h *HostHelper) CanUseNsenterMounter() (bool, error) {
 // for OpenShift volumes
 func (h *HostHelper) EnsureVolumeShare() error {
 	cmd := fmt.Sprintf(ensureVolumeShareCmd, h.volumesDir)
-	rc, err := h.runner().
+	_, rc, err := h.runner().
 		Image(h.image).
 		DiscardContainer().
 		HostPid().
@@ -138,7 +138,7 @@ func (h *HostHelper) UploadFileToContainer(src, dst string) error {
 
 // Hostname retrieves the FQDN of the Docker host machine
 func (h *HostHelper) Hostname() (string, error) {
-	hostname, _, _, err := h.runner().
+	_, hostname, _, _, err := h.runner().
 		Image(h.image).
 		HostNetwork().
 		HostPid().
@@ -168,7 +168,7 @@ func (h *HostHelper) EnsureHostDirectories(createVolumeShare bool) error {
 	}
 	if len(dirs) > 0 {
 		cmd := fmt.Sprintf(cmdEnsureHostDirs, strings.Join(dirs, " "))
-		rc, err := h.runner().
+		_, rc, err := h.runner().
 			Image(h.image).
 			DiscardContainer().
 			Privileged().

--- a/pkg/oc/bootstrap/docker/join.go
+++ b/pkg/oc/bootstrap/docker/join.go
@@ -61,8 +61,8 @@ func NewCmdJoin(name, fullName string, f *osclientcmd.Factory, in io.Reader, out
 		Long:    cmdJoinLong,
 		Example: fmt.Sprintf(cmdJoinExample, fullName),
 		Run: func(c *cobra.Command, args []string) {
-			kcmdutil.CheckErr(config.Complete(f, c))
-			kcmdutil.CheckErr(config.Validate(out))
+			kcmdutil.CheckErr(config.Complete(f, c, out))
+			kcmdutil.CheckErr(config.Validate())
 			if err := config.Start(out); err != nil {
 				os.Exit(1)
 			}
@@ -86,7 +86,7 @@ func (config *ClientJoinConfig) Bind(flags *pflag.FlagSet) {
 }
 
 // Complete initializes fields based on command parameters and execution environment
-func (c *ClientJoinConfig) Complete(f *osclientcmd.Factory, cmd *cobra.Command) error {
+func (c *ClientJoinConfig) Complete(f *osclientcmd.Factory, cmd *cobra.Command, out io.Writer) error {
 	if len(c.Secret) == 0 && c.In != nil {
 		fmt.Fprintf(c.Out, "Please paste the contents of your secret here and hit ENTER:\n")
 		data, err := ioutil.ReadAll(c.In)
@@ -96,7 +96,7 @@ func (c *ClientJoinConfig) Complete(f *osclientcmd.Factory, cmd *cobra.Command) 
 		c.Secret = string(data)
 	}
 
-	if err := c.CommonStartConfig.Complete(f, cmd); err != nil {
+	if err := c.CommonStartConfig.Complete(f, cmd, out); err != nil {
 		return err
 	}
 

--- a/pkg/oc/bootstrap/docker/openshift/admin.go
+++ b/pkg/oc/bootstrap/docker/openshift/admin.go
@@ -7,9 +7,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"strings"
 
-	"github.com/golang/glog"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -24,6 +22,7 @@ import (
 	"github.com/openshift/origin/pkg/cmd/server/admin"
 	"github.com/openshift/origin/pkg/oc/admin/policy"
 	"github.com/openshift/origin/pkg/oc/bootstrap/docker/errors"
+	"github.com/openshift/origin/pkg/oc/bootstrap/docker/run"
 	"github.com/openshift/origin/pkg/oc/cli/util/clientcmd"
 	securitytypedclient "github.com/openshift/origin/pkg/security/generated/internalclientset/typed/security/internalversion"
 )
@@ -101,7 +100,7 @@ func (h *Helper) InstallRegistry(kubeClient kclientset.Interface, f *clientcmd.F
 }
 
 // InstallRouter installs a default router on the OpenShift server
-func (h *Helper) InstallRouter(kubeClient kclientset.Interface, f *clientcmd.Factory, configDir, images, hostIP string, portForwarding bool, out, errout io.Writer) error {
+func (h *Helper) InstallRouter(imageRunHelper *run.Runner, ocImage string, kubeClient kclientset.Interface, f *clientcmd.Factory, configDir, images, hostIP string, portForwarding bool, out, errout io.Writer) error {
 	_, err := kubeClient.Core().Services(DefaultNamespace).Get(SvcRouter, metav1.GetOptions{})
 	if err == nil {
 		// Router service already exists, nothing to do
@@ -173,26 +172,56 @@ func (h *Helper) InstallRouter(kubeClient kclientset.Interface, f *clientcmd.Fac
 		return errors.NewError("cannot create aggregate router cert").WithCause(err)
 	}
 
-	err = h.hostHelper.UploadFileToContainer(filepath.Join(masterDir, "router.pem"), routerCertPath)
-	if err != nil {
-		return errors.NewError("cannot upload router cert to origin container").WithCause(err)
-	}
-
-	_, stdErr, err := h.execHelper.Command("oc", "adm", "router",
+	flags := []string{
+		"adm", "router",
+		"--dry-run",
+		"--output=json",
 		"--host-ports=true",
 		fmt.Sprintf("--host-network=%v", !portForwarding),
 		fmt.Sprintf("--images=%s", images),
-		fmt.Sprintf("--default-cert=%s", routerCertPath)).Output()
-
+		fmt.Sprintf("--default-cert=%s", routerCertPath),
+	}
+	_, routerJSON, stdErr, _, err := imageRunHelper.Image(ocImage).
+		Privileged().
+		DiscardContainer().
+		HostNetwork().
+		HostPid().
+		Bind(masterDir + ":" + masterConfigDir).
+		Entrypoint("oc").
+		Command(flags...).Output()
 	if err != nil {
-		// In origin v1.3.1, the 'oc adm router' command exits with an error
-		// about an existing router service account. However, the router is
-		// created successfully.
-		if strings.Contains(stdErr, "error: serviceaccounts \"router\" already exists") {
-			glog.V(2).Infof("ignoring error about existing router service account")
-		} else {
-			return errors.NewError("error creating router").WithCause(err)
+		return errors.NewError("cannot generate router resources").WithCause(err).WithDetails(stdErr)
+	}
+
+	obj, err := runtime.Decode(legacyscheme.Codecs.UniversalDecoder(), []byte(routerJSON))
+	if err != nil {
+		return errors.NewError("cannot decode registry JSON output").WithCause(err).WithDetails(routerJSON)
+	}
+	objList := obj.(*kapi.List)
+
+	if errs := runtime.DecodeList(objList.Items, legacyscheme.Codecs.UniversalDecoder()); len(errs) > 0 {
+		return errors.NewError("cannot decode registry objects").WithCause(utilerrors.NewAggregate(errs))
+	}
+
+	// Create objects
+	mapper := clientcmd.ResourceMapper(f)
+	bulk := &configcmd.Bulk{
+		Mapper: mapper,
+		Op:     configcmd.Create,
+	}
+	if errs := bulk.Run(objList, DefaultNamespace); len(errs) > 0 {
+		filteredErrs := []error{}
+		for _, err := range errs {
+			if apierrors.IsAlreadyExists(err) {
+				continue
+			}
+			filteredErrs = append(filteredErrs, err)
 		}
+		if len(filteredErrs) == 0 {
+			return nil
+		}
+		err = utilerrors.NewAggregate(filteredErrs)
+		return errors.NewError("cannot create router object").WithCause(err)
 	}
 
 	return nil

--- a/pkg/oc/bootstrap/docker/openshift/cnetwork.go
+++ b/pkg/oc/bootstrap/docker/openshift/cnetwork.go
@@ -31,7 +31,7 @@ exit 1
 // TestContainerNetworking launches a container that will check whether the container
 // can communicate with the master API and DNS endpoints.
 func (h *Helper) TestContainerNetworking(ip string) error {
-	_, err := h.runHelper.New().Image(h.image).
+	_, _, err := h.runHelper.New().Image(h.image).
 		DiscardContainer().
 		Env(fmt.Sprintf("MASTER_IP=%s", ip)).
 		DNS("172.30.0.1").

--- a/pkg/oc/bootstrap/docker/openshift/helper.go
+++ b/pkg/oc/bootstrap/docker/openshift/helper.go
@@ -149,7 +149,7 @@ func NewHelper(dockerHelper *dockerhelper.Helper, hostHelper *host.HostHelper, i
 }
 
 func (h *Helper) TestPorts(ports []int) error {
-	portData, _, _, err := h.runHelper.New().Image(h.image).
+	_, portData, _, _, err := h.runHelper.New().Image(h.image).
 		DiscardContainer().
 		Privileged().
 		HostNetwork().
@@ -208,7 +208,7 @@ func (h *Helper) TestForwardedIP(ip string) error {
 }
 
 func (h *Helper) DetermineNodeHost(hostConfigDir string, names ...string) (string, error) {
-	result, _, _, err := h.runHelper.New().Image(h.image).
+	_, result, _, _, err := h.runHelper.New().Image(h.image).
 		DiscardContainer().
 		Privileged().
 		HostNetwork().
@@ -226,7 +226,7 @@ func (h *Helper) ServerIP() (string, error) {
 	if len(h.serverIP) > 0 {
 		return h.serverIP, nil
 	}
-	result, _, _, err := h.runHelper.New().Image(h.image).
+	_, result, _, _, err := h.runHelper.New().Image(h.image).
 		DiscardContainer().
 		Privileged().
 		HostNetwork().
@@ -240,7 +240,7 @@ func (h *Helper) ServerIP() (string, error) {
 
 // OtherIPs tries to find other IPs besides the argument IP for the Docker host
 func (h *Helper) OtherIPs(excludeIP string) ([]string, error) {
-	result, _, _, err := h.runHelper.New().Image(h.image).
+	_, result, _, _, err := h.runHelper.New().Image(h.image).
 		DiscardContainer().
 		Privileged().
 		HostNetwork().
@@ -342,7 +342,7 @@ func (h *Helper) Start(opt *StartOptions, out io.Writer) (string, error) {
 			fmt.Sprintf("--hostname=%s", defaultNodeName),
 			fmt.Sprintf("--public-master=https://%s:8443", publicHost),
 		}
-		_, err := h.runHelper.New().Image(h.image).
+		_, _, err := h.runHelper.New().Image(h.image).
 			Privileged().
 			DiscardContainer().
 			HostNetwork().
@@ -651,7 +651,7 @@ func (h *Helper) ServerPrereleaseVersion() (semver.Version, error) {
 		return *h.prereleaseVersion, nil
 	}
 
-	versionText, _, _, err := h.runHelper.New().Image(h.image).
+	_, versionText, _, _, err := h.runHelper.New().Image(h.image).
 		Command("version").
 		DiscardContainer().
 		Output()
@@ -945,7 +945,7 @@ fi
 
 kubelet --help | grep -- "--cgroup-driver"
 `
-	rc, err := h.runHelper.New().Image(h.image).
+	_, rc, err := h.runHelper.New().Image(h.image).
 		DiscardContainer().
 		Entrypoint("/bin/bash").
 		Command("-c", script).

--- a/pkg/oc/bootstrap/docker/openshift/helper.go
+++ b/pkg/oc/bootstrap/docker/openshift/helper.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -577,7 +578,12 @@ func masterHTTPClient(localConfig string) (*http.Client, error) {
 // copyConfig copies the OpenShift configuration directory from the
 // server directory into a local temporary directory.
 func (h *Helper) copyConfig() (string, error) {
-	tempDir, err := ioutil.TempDir("", "openshift-config")
+	tmpDirFn := os.TempDir
+	// On OSX $TMPDIR does not return path that Docker for Mac allow for mounting.
+	if runtime.GOOS == "darwin" {
+		tmpDirFn = func() string { return "/tmp" }
+	}
+	tempDir, err := ioutil.TempDir(tmpDirFn(), "openshift-config")
 	if err != nil {
 		return "", err
 	}

--- a/pkg/oc/bootstrap/docker/run/run.go
+++ b/pkg/oc/bootstrap/docker/run/run.go
@@ -158,14 +158,14 @@ func (h *Runner) Start() (string, error) {
 }
 
 // Output starts the container, waits for it to finish and returns its output
-func (h *Runner) Output() (string, string, int, error) {
+func (h *Runner) Output() (string, string, string, int, error) {
 	return h.runWithOutput()
 }
 
 // Run executes the container and waits until it completes
-func (h *Runner) Run() (int, error) {
-	_, _, rc, err := h.runWithOutput()
-	return rc, err
+func (h *Runner) Run() (string, int, error) {
+	id, _, _, rc, err := h.runWithOutput()
+	return id, rc, err
 }
 
 func (h *Runner) Create() (string, error) {
@@ -234,10 +234,10 @@ func (h *Runner) startContainer(id string) error {
 	return nil
 }
 
-func (h *Runner) runWithOutput() (string, string, int, error) {
+func (h *Runner) runWithOutput() (string, string, string, int, error) {
 	id, err := h.Create()
 	if err != nil {
-		return "", "", 0, err
+		return "", "", "", 0, err
 	}
 	if h.removeContainer {
 		defer func() {
@@ -252,14 +252,14 @@ func (h *Runner) runWithOutput() (string, string, int, error) {
 	err = h.startContainer(id)
 	if err != nil {
 		glog.V(2).Infof("Error occurred starting container %q: %v", id, err)
-		return "", "", 0, err
+		return "", "", "", 0, err
 	}
 
 	glog.V(5).Infof("Waiting for container %q", id)
 	rc, err := h.client.ContainerWait(id)
 	if err != nil {
 		glog.V(2).Infof("Error occurred waiting for container %q: %v", id, err)
-		return "", "", 0, err
+		return "", "", "", 0, err
 	}
 	glog.V(5).Infof("Done waiting for container %q, rc=%d", id, rc)
 
@@ -272,17 +272,17 @@ func (h *Runner) runWithOutput() (string, string, int, error) {
 	err = h.client.ContainerLogs(id, types.ContainerLogsOptions{ShowStdout: true, ShowStderr: true}, stdOut, stdErr)
 	if err != nil {
 		glog.V(2).Infof("Error occurred while reading logs: %v", err)
-		return "", "", 0, err
+		return "", "", "", 0, err
 	}
 	glog.V(5).Infof("Done reading logs from container %q", id)
 
 	glog.V(5).Infof("Stdout:\n%s", stdOut.String())
 	glog.V(5).Infof("Stderr:\n%s", stdErr.String())
 	if rc != 0 || err != nil {
-		return stdOut.String(), stdErr.String(), rc, newRunError(rc, err, stdOut.String(), stdErr.String(), h.config)
+		return id, stdOut.String(), stdErr.String(), rc, newRunError(rc, err, stdOut.String(), stdErr.String(), h.config)
 	}
 	glog.V(4).Infof("Container run successful\n")
-	return stdOut.String(), stdErr.String(), rc, nil
+	return id, stdOut.String(), stdErr.String(), rc, nil
 }
 
 // printConfig prints out the relevant parts of a container's Docker config

--- a/pkg/oc/bootstrap/docker/run_self_hosted.go
+++ b/pkg/oc/bootstrap/docker/run_self_hosted.go
@@ -1,0 +1,457 @@
+package docker
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"path"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/golang/glog"
+	"k8s.io/apiserver/pkg/authentication/serviceaccount"
+	"k8s.io/client-go/util/retry"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	kerrorutils "k8s.io/apimachinery/pkg/util/errors"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	kclientcmd "k8s.io/client-go/tools/clientcmd"
+	"k8s.io/kubernetes/pkg/api/legacyscheme"
+	kapi "k8s.io/kubernetes/pkg/apis/core"
+	"k8s.io/kubernetes/pkg/kubectl/resource"
+
+	securityclient "github.com/openshift/client-go/security/clientset/versioned"
+	"github.com/openshift/origin/pkg/api"
+	"github.com/openshift/origin/pkg/bulk"
+	"github.com/openshift/origin/pkg/oc/bootstrap"
+	"github.com/openshift/origin/pkg/oc/bootstrap/clusterup/kubeapiserver"
+	"github.com/openshift/origin/pkg/oc/bootstrap/clusterup/kubelet"
+	"github.com/openshift/origin/pkg/oc/bootstrap/clusterup/staticpods"
+	"github.com/openshift/origin/pkg/oc/bootstrap/docker/openshift"
+	"github.com/openshift/origin/pkg/oc/bootstrap/docker/run"
+	templateapi "github.com/openshift/origin/pkg/template/apis/template"
+	templateclientshim "github.com/openshift/origin/pkg/template/client/internalversion"
+	templateclient "github.com/openshift/origin/pkg/template/generated/internalclientset"
+)
+
+var (
+	// staticPodLocations should only include those pods that *must* be run statically because they
+	// bring up the services required to run the workload controllers.
+	// etcd, kube-apiserver, kube-controller-manager, kube-scheduler (this is because sig-scheduling is expanding the scheduler responsibilities)
+	staticPodLocations = []string{
+		"install/etcd/etcd.yaml",
+		"install/kube-apiserver/apiserver.yaml",
+		"install/kube-controller-manager/kube-controller-manager.yaml",
+		"install/kube-scheduler/kube-scheduler.yaml",
+	}
+
+	// componentsToInstall DOES NOT INSTALL IN ORDER.  They are installed separately and expected to come up
+	// in any order and self-organize into something that works.  Remember, when the whole system crashes and restarts
+	// you don't get to choose your restart order.  Plan accordingly.  No bugs or attempts at interlocks will be accepted
+	// in cluster up.
+	// TODO we can take a guess at readiness by making sure that pods in the namespace exist and all pods are healthy
+	// TODO it's not perfect, but its fairly good as a starting point.
+	componentsToInstall = []componentRequest{
+		{location: "openshift-controller-manager", privilegedSANames: []string{"openshift-controller-manager"}},
+	}
+)
+
+type componentRequest struct {
+	// location is the name of the folder in install and the name of the namespace you're installed into
+	location          string
+	privilegedSANames []string
+}
+
+func (c *ClientStartConfig) StartSelfHosted(out io.Writer) error {
+	fmt.Fprintf(out, "Starting OpenShift using %s ...\n", c.openshiftImage())
+
+	if c.PortForwarding {
+		err := openshift.CheckSocat()
+		if err != nil {
+			return err
+		}
+	}
+	// TODO allow specifying config. If you specify config for a thing that has prereq, you must also specify all of its prereqs
+
+	masterConfigDir, err := c.makeMasterConfig(out)
+	if err != nil {
+		return err
+	}
+	glog.V(1).Infof("master-config at %q\n", masterConfigDir)
+
+	nodeConfigDir, err := c.makeNodeConfig(out, masterConfigDir)
+	if err != nil {
+		return err
+	}
+	glog.V(1).Infof("node-config at %q\n", nodeConfigDir)
+
+	kubeletFlags, err := c.makeKubeletFlags(out, nodeConfigDir)
+	if err != nil {
+		return err
+	}
+	glog.V(1).Infof("kubeletflags := %s\n", kubeletFlags)
+
+	kubeletContainerID, err := c.startKubelet(out, masterConfigDir, nodeConfigDir, kubeletFlags)
+	if err != nil {
+		return err
+	}
+	glog.V(1).Infof("started kubelet in container %q\n", kubeletContainerID)
+
+	substitutions := map[string]string{
+		"/path/to/master/config-dir": masterConfigDir,
+	}
+	for _, staticPodLocation := range staticPodLocations {
+		if err := staticpods.UpsertStaticPod(staticPodLocation, substitutions, c.PodManifestDir); err != nil {
+			return err
+		}
+	}
+
+	clientConfigBuilder, err := kclientcmd.LoadFromFile(filepath.Join(masterConfigDir, "admin.kubeconfig"))
+	if err != nil {
+		return err
+	}
+	overrides := &kclientcmd.ConfigOverrides{}
+	defaultCfg := kclientcmd.NewDefaultClientConfig(*clientConfigBuilder, overrides)
+	clientConfig, err := defaultCfg.ClientConfig()
+	if err != nil {
+		return err
+	}
+
+	// wait for the apiserver to be ready
+	waitForHealthyKubeAPIServer(clientConfig)
+
+	templateSubstitutionValues := map[string]string{
+		"MASTER_CONFIG_HOST_PATH": masterConfigDir,
+	}
+
+	waitGroup := sync.WaitGroup{}
+	for _, component := range componentsToInstall {
+		glog.Infof("Installing %q...", component.location)
+		waitGroup.Add(1)
+
+		go func() {
+			defer utilruntime.HandleCrash()
+			defer waitGroup.Done()
+
+			if err := component.install(clientConfig, templateSubstitutionValues); err != nil {
+				panic(err)
+			}
+		}()
+	}
+	waitGroup.Wait()
+	glog.Info("components installed")
+
+	// TODO remove this linkage.  State like this doesn't belong on the struct and should be passed through for each invocation
+	c.LocalConfigDir = path.Dir(masterConfigDir)
+
+	return nil
+}
+
+// makeMasterConfig returns the directory where a generated masterconfig lives
+func (c *ClientStartConfig) makeMasterConfig(out io.Writer) (string, error) {
+	publicHost := c.PublicHostname
+	if len(publicHost) == 0 {
+		publicHost = c.ServerIP
+	}
+
+	imageRunningHelper := run.NewRunHelper(c.DockerHelper())
+	container := kubeapiserver.NewKubeAPIServerStartConfig()
+	// TODO follow the args pattern of the others
+	container.MasterImage = c.openshiftImage()
+	container.ImageFormat = c.imageFormat()
+	container.DNSPort = c.DNSPort
+	container.PublicHost = publicHost
+
+	masterConfigDir, err := container.MakeMasterConfig(c.GetDockerClient(out), imageRunningHelper.New(), out)
+	if err != nil {
+		return "", fmt.Errorf("error creating master config: %v", err)
+	}
+
+	return masterConfigDir, nil
+}
+
+// makeNodeConfig returns the directory where a generated nodeconfig lives
+func (c *ClientStartConfig) makeNodeConfig(out io.Writer, masterConfigDir string) (string, error) {
+	defaultNodeName := "localhost"
+
+	imageRunningHelper := run.NewRunHelper(c.DockerHelper())
+	container := kubelet.NewNodeStartConfig()
+	container.ContainerBinds = append(container.ContainerBinds, masterConfigDir+":/var/lib/origin/openshift.local.masterconfig:z")
+	container.NodeImage = c.openshiftImage()
+	container.Args = []string{
+		fmt.Sprintf("--certificate-authority=%s", "/var/lib/origin/openshift.local.masterconfig/ca.crt"),
+		fmt.Sprintf("--dns-bind-address=0.0.0.0:%d", c.DNSPort),
+		fmt.Sprintf("--hostnames=%s", defaultNodeName),
+		fmt.Sprintf("--hostnames=%s", "127.0.0.1"),
+		fmt.Sprintf("--images=%s", c.imageFormat()),
+		fmt.Sprintf("--node=%s", defaultNodeName),
+		fmt.Sprintf("--node-client-certificate-authority=%s", "/var/lib/origin/openshift.local.masterconfig/ca.crt"),
+		fmt.Sprintf("--signer-cert=%s", "/var/lib/origin/openshift.local.masterconfig/ca.crt"),
+		fmt.Sprintf("--signer-key=%s", "/var/lib/origin/openshift.local.masterconfig/ca.key"),
+		fmt.Sprintf("--signer-serial=%s", "/var/lib/origin/openshift.local.masterconfig/ca.serial.txt"),
+		fmt.Sprintf("--volume-dir=%s", c.HostVolumesDir),
+	}
+
+	nodeConfigDir, err := container.MakeNodeConfig(imageRunningHelper.New(), out)
+	if err != nil {
+		return "", fmt.Errorf("error creating node config: %v", err)
+	}
+
+	return nodeConfigDir, nil
+}
+
+// makeKubeletFlags returns the kubelet flags
+func (c *ClientStartConfig) makeKubeletFlags(out io.Writer, nodeConfigDir string) ([]string, error) {
+	imageRunningHelper := run.NewRunHelper(c.DockerHelper())
+	container := kubelet.NewKubeletStartFlags()
+	container.ContainerBinds = append(container.ContainerBinds, nodeConfigDir+":/var/lib/origin/openshift.local.config/node:z")
+	container.Environment = c.Environment
+	container.NodeImage = c.openshiftImage()
+	container.Environment = c.Environment
+	container.UseSharedVolume = !c.UseNsenterMount
+
+	kubeletFlags, err := container.MakeKubeletFlags(imageRunningHelper.New(), out)
+	if err != nil {
+		return nil, fmt.Errorf("error creating node config: %v", err)
+	}
+
+	// TODO make this non-broken, but for now spaces are evil
+	return strings.Split(strings.TrimSpace(kubeletFlags), " "), nil
+}
+
+// startKubelet returns the container id
+func (c *ClientStartConfig) startKubelet(out io.Writer, masterConfigDir, nodeConfigDir string, kubeletFlags []string) (string, error) {
+	dockerRoot, err := c.DockerHelper().DockerRoot()
+	if err != nil {
+		return "", err
+	}
+
+	imageRunningHelper := run.NewRunHelper(c.DockerHelper())
+	container := kubelet.NewKubeletRunConfig()
+	container.ContainerBinds = append(container.ContainerBinds, nodeConfigDir+":/var/lib/origin/openshift.local.config/node:z")
+	container.ContainerBinds = append(container.ContainerBinds, masterConfigDir+":/etc/origin/master:z")
+	container.ContainerBinds = append(container.ContainerBinds, c.PodManifestDir+":/var/lib/origin/pod-manifests:z")
+	if len(c.HostDataDir) > 0 {
+		container.ContainerBinds = append(container.ContainerBinds, fmt.Sprintf("%s:/var/lib/etcd:z", c.HostDataDir))
+	}
+	container.NodeImage = c.openshiftImage()
+	container.Environment = c.Environment
+	container.DockerRoot = dockerRoot
+	container.UseSharedVolume = !c.UseNsenterMount
+	container.HostVolumesDir = c.HostVolumesDir
+	container.HTTPProxy = c.HTTPProxy
+	container.HTTPSProxy = c.HTTPSProxy
+	container.NoProxy = c.NoProxy
+	container.Args = append(kubeletFlags, "--pod-manifest-path=/var/lib/origin/pod-manifests")
+
+	kubeletContainerID, err := container.MakeNodeConfig(imageRunningHelper.New(), out)
+	if err != nil {
+		return "", fmt.Errorf("error creating node config: %v", err)
+	}
+
+	return kubeletContainerID, nil
+}
+
+func waitForHealthyKubeAPIServer(clientConfig *rest.Config) error {
+	var healthzContent string
+	// If apiserver is not running we should wait for some time and fail only then. This is particularly
+	// important when we start apiserver and controller manager at the same time.
+	err := wait.PollImmediate(time.Second, 5*time.Minute, func() (bool, error) {
+		discoveryClient, err := discovery.NewDiscoveryClientForConfig(clientConfig)
+		if err != nil {
+			return false, nil
+		}
+
+		healthStatus := 0
+		resp := discoveryClient.RESTClient().Get().AbsPath("/healthz").Do().StatusCode(&healthStatus)
+		if resp.Error() != nil {
+			glog.Errorf("Server isn't healthy yet.  Waiting a little while. %v", resp.Error())
+			return false, nil
+		}
+		content, _ := resp.Raw()
+		healthzContent = string(content)
+		if healthStatus != http.StatusOK {
+			glog.Errorf("Server isn't healthy yet.  Waiting a little while. %v", healthStatus)
+			return false, nil
+		}
+
+		return true, nil
+	})
+	if err != nil {
+		glog.Error(healthzContent)
+	}
+
+	return err
+}
+
+func (c componentRequest) install(clientConfig *rest.Config, substitutionValues map[string]string) error {
+	kubeClient, err := kubernetes.NewForConfig(clientConfig)
+	if err != nil {
+		return nil
+	}
+	if _, err := kubeClient.CoreV1().Namespaces().Create(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: c.location}}); err != nil {
+		return nil
+	}
+
+	for _, saName := range c.privilegedSANames {
+		// this has to be built here, because the first thing we will install is the openshift apiserver, which hosts our SCCs,
+		// which means its namespace skips the SCC check, and we won't be able to create a working client
+		securityClient, err := securityclient.NewForConfig(clientConfig)
+		if err != nil {
+			return err
+		}
+		// TODO use patch
+		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			privilegedSCC, err := securityClient.SecurityV1().SecurityContextConstraints().Get("privileged", metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			privilegedSCC.Users = append(privilegedSCC.Users, serviceaccount.MakeUsername(c.location, saName))
+			if _, err := securityClient.SecurityV1().SecurityContextConstraints().Update(privilegedSCC); err != nil {
+				return err
+			}
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	template, err := processTemplate(clientConfig, path.Join("install", c.location, "install.yaml"), c.location, substitutionValues)
+	if err != nil {
+		return err
+	}
+
+	if err := createObjects(clientConfig, template.Objects, c.location); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func createObjects(clientConfig *rest.Config, inObjs []runtime.Object, namespace string) error {
+	// we end up with a bunch of unknowns. We can actually roundtrip them back in a unstructured and I think this works
+	// TODO unbork this.
+	objs := []runtime.Object{}
+	for _, inObj := range inObjs {
+		buf := &bytes.Buffer{}
+		if err := unstructured.UnstructuredJSONScheme.Encode(inObj, buf); err != nil {
+			return nil
+		}
+		unstructuredObj, err := runtime.Decode(unstructured.UnstructuredJSONScheme, buf.Bytes())
+		if err != nil {
+			return err
+		}
+		objs = append(objs, unstructuredObj)
+	}
+
+	mapper, typer := legacyscheme.Registry.RESTMapper(), legacyscheme.Scheme
+
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(clientConfig)
+	if err != nil {
+		return err
+	}
+
+	// Create objects
+	bulkOperation := &bulk.Bulk{}
+
+	bulkOperation.DynamicMapper = &resource.Mapper{
+		RESTMapper:  mapper,
+		ObjectTyper: typer,
+		ClientMapper: resource.ClientMapperFunc(func(mapping *meta.RESTMapping) (resource.RESTClient, error) {
+			return unstructuredClientForMapping(mapping, clientConfig)
+		}),
+	}
+	bulkOperation.Mapper = &resource.Mapper{
+		RESTMapper:   mapper,
+		ObjectTyper:  typer,
+		ClientMapper: bulk.ClientMapperFromConfig(clientConfig),
+	}
+	bulkOperation.PreferredSerializationOrder = bulk.PreferredSerializationOrder(discoveryClient)
+	bulkOperation.Op = bulk.Create
+
+	itemsToCreate := &kapi.List{
+		Items: objs,
+	}
+	if errs := bulkOperation.Run(itemsToCreate, namespace); len(errs) > 0 {
+		filteredErrs := []error{}
+		for _, err := range errs {
+			filteredErrs = append(filteredErrs, err)
+		}
+		if len(filteredErrs) == 0 {
+			return nil
+		}
+		err = kerrorutils.NewAggregate(filteredErrs)
+		return err
+	}
+
+	return nil
+}
+
+func processTemplate(clientConfig *rest.Config, location, namespace string, substitutionValues map[string]string) (*templateapi.Template, error) {
+	data, err := bootstrap.Asset(location)
+	if err != nil {
+		return nil, err
+	}
+	templateObj, err := runtime.Decode(legacyscheme.Codecs.UniversalDecoder(), data)
+	if err != nil {
+		return nil, err
+	}
+	template := templateObj.(*templateapi.Template)
+
+	injectUserVars(template, substitutionValues)
+
+	templateClient, err := templateclient.NewForConfig(clientConfig)
+	if err != nil {
+		return nil, err
+	}
+	templateProcessor := templateclientshim.NewTemplateProcessorClient(templateClient.Template().RESTClient(), namespace)
+
+	return templateProcessor.Process(template)
+}
+
+func injectUserVars(t *templateapi.Template, values map[string]string) {
+	for param, val := range values {
+		v := getParameterByName(t, param)
+		if v != nil {
+			v.Value = val
+			v.Generate = ""
+		}
+	}
+}
+
+func getParameterByName(t *templateapi.Template, name string) *templateapi.Parameter {
+	for i, param := range t.Parameters {
+		if param.Name == name {
+			return &(t.Parameters[i])
+		}
+	}
+	return nil
+}
+
+// TODO this is useful for building a generic bulk operations, try to make it more generic
+func unstructuredClientForMapping(mapping *meta.RESTMapping, clientConfig *rest.Config) (resource.RESTClient, error) {
+	cfg := *clientConfig
+
+	cfg.APIPath = "/apis"
+	if mapping.GroupVersionKind.Group == api.GroupName {
+		cfg.APIPath = "/api"
+	}
+	gv := mapping.GroupVersionKind.GroupVersion()
+	cfg.ContentConfig = dynamic.ContentConfig()
+	cfg.GroupVersion = &gv
+
+	return rest.RESTClientFor(&cfg)
+}

--- a/pkg/oc/bootstrap/docker/run_self_hosted.go
+++ b/pkg/oc/bootstrap/docker/run_self_hosted.go
@@ -75,8 +75,6 @@ type componentRequest struct {
 }
 
 func (c *ClientStartConfig) StartSelfHosted(out io.Writer) error {
-	fmt.Fprintf(out, "Starting OpenShift using %s ...\n", c.openshiftImage())
-
 	if c.PortForwarding {
 		err := openshift.CheckSocat()
 		if err != nil {

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -247,6 +247,11 @@
 // examples/jenkins/pipeline/openshift-client-plugin-pipeline.yaml
 // examples/jenkins/pipeline/samplepipeline.yaml
 // examples/quickstarts/cakephp-mysql.json
+// install/etcd/etcd.yaml
+// install/kube-apiserver/apiserver.yaml
+// install/kube-controller-manager/kube-controller-manager.yaml
+// install/kube-scheduler/kube-scheduler.yaml
+// install/openshift-controller-manager/install.yaml
 // install/origin-web-console/console-config.yaml
 // install/origin-web-console/console-template.yaml
 // install/origin-web-console/rbac-template.yaml
@@ -29098,6 +29103,345 @@ func examplesQuickstartsCakephpMysqlJsonCakephpMysqlJson() (*asset, error) {
 	return a, nil
 }
 
+var _installEtcdEtcdYaml = []byte(`kind: Pod
+apiVersion: v1
+metadata:
+  name: master-etcd
+  namespace: kube-system
+  labels:
+    openshift.io/control-plane: "true"
+    openshift.io/component: etcd
+spec:
+  restartPolicy: Always
+  hostNetwork: true
+  containers:
+  - name: etcd
+    image: openshift/origin:latest
+    workingDir: /var/lib/etcd
+    command: ["/bin/sh", "-c"]
+    args:
+    - |
+      #!/bin/sh
+      set -o allexport
+      exec openshift start etcd --config=/etc/origin/master/master-config.yaml
+    securityContext:
+      privileged: true
+    volumeMounts:
+     - mountPath: /etc/origin/master/
+       name: master-config
+       readOnly: true
+     - mountPath: /var/lib/etcd/
+       name: master-data
+  volumes:
+  - name: master-config
+    hostPath:
+      path: /path/to/master/config-dir
+  - name: master-data
+    hostPath:
+      path: /var/lib/etcd`)
+
+func installEtcdEtcdYamlBytes() ([]byte, error) {
+	return _installEtcdEtcdYaml, nil
+}
+
+func installEtcdEtcdYaml() (*asset, error) {
+	bytes, err := installEtcdEtcdYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "install/etcd/etcd.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _installKubeApiserverApiserverYaml = []byte(`kind: Pod
+apiVersion: v1
+metadata:
+  name: master-api
+  namespace: kube-system
+  labels:
+    openshift.io/control-plane: "true"
+    openshift.io/component: api
+spec:
+  restartPolicy: Always
+  hostNetwork: true
+  containers:
+  - name: api
+    image: openshift/origin:latest
+    command: ["/bin/bash", "-c"]
+    args:
+    - |
+      #!/bin/bash
+      set -euo pipefail
+      if [[ -f /etc/origin/master/master.env ]]; then
+        set -o allexport
+        source /etc/origin/master/master.env
+      fi
+      exec openshift start master api --config=/etc/origin/master/master-config.yaml
+    securityContext:
+      privileged: true
+    volumeMounts:
+     - mountPath: /etc/origin/master/
+       name: master-config
+     - mountPath: /etc/origin/cloudprovider/
+       name: master-cloud-provider
+     - mountPath: /var/lib/origin/
+       name: master-data
+    livenessProbe:
+      httpGet:
+        scheme: HTTPS
+        port: 8443
+        path: healthz
+  volumes:
+  - name: master-config
+    hostPath:
+      path: /path/to/master/config-dir
+  - name: master-cloud-provider
+    hostPath:
+      path: /etc/origin/cloudprovider
+  - name: master-data
+    hostPath:
+      path: /var/lib/origin`)
+
+func installKubeApiserverApiserverYamlBytes() ([]byte, error) {
+	return _installKubeApiserverApiserverYaml, nil
+}
+
+func installKubeApiserverApiserverYaml() (*asset, error) {
+	bytes, err := installKubeApiserverApiserverYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "install/kube-apiserver/apiserver.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _installKubeControllerManagerKubeControllerManagerYaml = []byte(`kind: Pod
+apiVersion: v1
+metadata:
+  name: kube-controller-manager
+  namespace: kube-system
+  labels:
+    openshift.io/control-plane: "true"
+    openshift.io/component: controllers
+spec:
+  restartPolicy: Always
+  hostNetwork: true
+  containers:
+  - name: controllers
+    image: openshift/origin:latest
+    command: ["hyperkube", "kube-controller-manager"]
+    args:
+    - "--enable-dynamic-provisioning=true"
+    - "--use-service-account-credentials=true"
+    - "--leader-elect-retry-period=3s"
+    - "--leader-elect-resource-lock=configmaps"
+    - "--controllers=*"
+    - "--controllers=-ttl"
+    - "--controllers=-bootstrapsigner"
+    - "--controllers=-tokencleaner"
+    - "--controllers=-horizontalpodautoscaling"
+    - "--pod-eviction-timeout=5m"
+    - "--cluster-signing-key-file="
+    - "--cluster-signing-cert-file="
+    - "--experimental-cluster-signing-duration=720h"
+    - "--root-ca-file=/etc/origin/master/ca-bundle.crt"
+    - "--port=10252"
+    - "--service-account-private-key-file=/etc/origin/master/serviceaccounts.private.key"
+    - "--kubeconfig=/etc/origin/master/openshift-master.kubeconfig"
+    - "--openshift-config=/etc/origin/master/master-config.yaml"
+    securityContext:
+      privileged: true
+    volumeMounts:
+     - mountPath: /etc/origin/master/
+       name: master-config
+     - mountPath: /etc/origin/cloudprovider/
+       name: master-cloud-provider
+    livenessProbe:
+      httpGet:
+        scheme: HTTP
+        port: 10252
+        path: healthz
+  volumes:
+  - name: master-config
+    hostPath:
+      path: /path/to/master/config-dir
+  - name: master-cloud-provider
+    hostPath:
+      path: /etc/origin/cloudprovider`)
+
+func installKubeControllerManagerKubeControllerManagerYamlBytes() ([]byte, error) {
+	return _installKubeControllerManagerKubeControllerManagerYaml, nil
+}
+
+func installKubeControllerManagerKubeControllerManagerYaml() (*asset, error) {
+	bytes, err := installKubeControllerManagerKubeControllerManagerYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "install/kube-controller-manager/kube-controller-manager.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _installKubeSchedulerKubeSchedulerYaml = []byte(`kind: Pod
+apiVersion: v1
+metadata:
+  name: kube-scheduler
+  namespace: kube-system
+  labels:
+    openshift.io/control-plane: "true"
+    openshift.io/component: scheduler
+spec:
+  restartPolicy: Always
+  hostNetwork: true
+  containers:
+  - name: scheduler
+    image: openshift/origin:latest
+    command: ["hyperkube", "kube-scheduler"]
+    args:
+    - "--leader-elect=true"
+    - "--leader-elect-resource-lock=configmaps"
+    - "--port=10251"
+    - "--kubeconfig=/etc/origin/master/openshift-master.kubeconfig"
+    - "--policy-config-file="
+    securityContext:
+      privileged: true
+    volumeMounts:
+     - mountPath: /etc/origin/master/
+       name: master-config
+     - mountPath: /etc/origin/cloudprovider/
+       name: master-cloud-provider
+    livenessProbe:
+      httpGet:
+        scheme: HTTP
+        port: 10251
+        path: healthz
+  volumes:
+  - name: master-config
+    hostPath:
+      path: /path/to/master/config-dir
+  - name: master-cloud-provider
+    hostPath:
+      path: /etc/origin/cloudprovider`)
+
+func installKubeSchedulerKubeSchedulerYamlBytes() ([]byte, error) {
+	return _installKubeSchedulerKubeSchedulerYaml, nil
+}
+
+func installKubeSchedulerKubeSchedulerYaml() (*asset, error) {
+	bytes, err := installKubeSchedulerKubeSchedulerYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "install/kube-scheduler/kube-scheduler.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _installOpenshiftControllerManagerInstallYaml = []byte(`# the openshift controller manager can use a template because the openshift-apiserver will be available first
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: openshift-controller-manager
+parameters:
+- name: IMAGE
+  value: openshift/origin:latest
+- name: NAMESPACE
+  value: openshift-controller-manager
+- name: LOGLEVEL
+  value: "0"
+- name: MASTER_CONFIG_HOST_PATH
+- name: NODE_SELECTOR
+  value: "{}"
+objects:
+
+# to create the tsb server
+- apiVersion: apps/v1
+  kind: DaemonSet
+  metadata:
+    namespace: ${NAMESPACE}
+    name: openshift-controller-manager
+    labels:
+      openshift.io/control-plane: "true"
+      openshift.io/component: controllers
+  spec:
+    selector:
+      matchLabels:
+        openshift.io/control-plane: "true"
+        openshift.io/component: controllers
+    template:
+      metadata:
+        name: openshift-controller-manager
+        labels:
+          openshift.io/control-plane: "true"
+          openshift.io/component: controllers
+      spec:
+        serviceAccountName: openshift-controller-manager
+        restartPolicy: Always
+        hostNetwork: true
+        containers:
+        - name: c
+          image: ${IMAGE}
+          imagePullPolicy: IfNotPresent
+          command: ["openshift", "start", "master", "controllers"]
+          args:
+          - "--listen=https://0.0.0.0:8444"
+          - "--config=/etc/origin/master/master-config.yaml"
+          ports:
+          - containerPort: 8444
+          securityContext:
+            privileged: true
+            runAsUser: 0
+          volumeMounts:
+           - mountPath: /etc/origin/master/
+             name: master-config
+           - mountPath: /etc/origin/cloudprovider/
+             name: master-cloud-provider
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8444
+              scheme: HTTPS
+        # sensitive files still sit on disk for now
+        volumes:
+        - name: master-config
+          hostPath:
+            path: ${MASTER_CONFIG_HOST_PATH}
+        - name: master-cloud-provider
+          hostPath:
+            path: /etc/origin/cloudprovider
+
+
+# to be able to assign powers to the process
+- apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    namespace: ${NAMESPACE}
+    name: openshift-controller-manager
+
+`)
+
+func installOpenshiftControllerManagerInstallYamlBytes() ([]byte, error) {
+	return _installOpenshiftControllerManagerInstallYaml, nil
+}
+
+func installOpenshiftControllerManagerInstallYaml() (*asset, error) {
+	bytes, err := installOpenshiftControllerManagerInstallYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "install/openshift-controller-manager/install.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 var _installOriginWebConsoleConsoleConfigYaml = []byte(`apiVersion: webconsole.config.openshift.io/v1
 kind: WebConsoleConfiguration
 clusterInfo:
@@ -30095,6 +30439,11 @@ var _bindata = map[string]func() (*asset, error){
 	"examples/jenkins/pipeline/openshift-client-plugin-pipeline.yaml": examplesJenkinsPipelineOpenshiftClientPluginPipelineYaml,
 	"examples/jenkins/pipeline/samplepipeline.yaml": examplesJenkinsPipelineSamplepipelineYaml,
 	"examples/quickstarts/cakephp-mysql.json/cakephp-mysql.json": examplesQuickstartsCakephpMysqlJsonCakephpMysqlJson,
+	"install/etcd/etcd.yaml": installEtcdEtcdYaml,
+	"install/kube-apiserver/apiserver.yaml": installKubeApiserverApiserverYaml,
+	"install/kube-controller-manager/kube-controller-manager.yaml": installKubeControllerManagerKubeControllerManagerYaml,
+	"install/kube-scheduler/kube-scheduler.yaml": installKubeSchedulerKubeSchedulerYaml,
+	"install/openshift-controller-manager/install.yaml": installOpenshiftControllerManagerInstallYaml,
 	"install/origin-web-console/console-config.yaml": installOriginWebConsoleConsoleConfigYaml,
 	"install/origin-web-console/console-template.yaml": installOriginWebConsoleConsoleTemplateYaml,
 	"install/origin-web-console/rbac-template.yaml": installOriginWebConsoleRbacTemplateYaml,
@@ -30210,6 +30559,21 @@ var _bintree = &bintree{nil, map[string]*bintree{
 		}},
 	}},
 	"install": &bintree{nil, map[string]*bintree{
+		"etcd": &bintree{nil, map[string]*bintree{
+			"etcd.yaml": &bintree{installEtcdEtcdYaml, map[string]*bintree{}},
+		}},
+		"kube-apiserver": &bintree{nil, map[string]*bintree{
+			"apiserver.yaml": &bintree{installKubeApiserverApiserverYaml, map[string]*bintree{}},
+		}},
+		"kube-controller-manager": &bintree{nil, map[string]*bintree{
+			"kube-controller-manager.yaml": &bintree{installKubeControllerManagerKubeControllerManagerYaml, map[string]*bintree{}},
+		}},
+		"kube-scheduler": &bintree{nil, map[string]*bintree{
+			"kube-scheduler.yaml": &bintree{installKubeSchedulerKubeSchedulerYaml, map[string]*bintree{}},
+		}},
+		"openshift-controller-manager": &bintree{nil, map[string]*bintree{
+			"install.yaml": &bintree{installOpenshiftControllerManagerInstallYaml, map[string]*bintree{}},
+		}},
 		"origin-web-console": &bintree{nil, map[string]*bintree{
 			"console-config.yaml": &bintree{installOriginWebConsoleConsoleConfigYaml, map[string]*bintree{}},
 			"console-template.yaml": &bintree{installOriginWebConsoleConsoleTemplateYaml, map[string]*bintree{}},

--- a/vendor/k8s.io/kubernetes/cmd/kube-controller-manager/app/controllermanager.go
+++ b/vendor/k8s.io/kubernetes/cmd/kube-controller-manager/app/controllermanager.go
@@ -555,10 +555,10 @@ func (c serviceAccountTokenControllerStarter) startServiceAccountTokenController
 		ctx.InformerFactory.Core().V1().ServiceAccounts(),
 		ctx.InformerFactory.Core().V1().Secrets(),
 		c.rootClientBuilder.ClientOrDie("tokens-controller"),
-		serviceaccountcontroller.TokensControllerOptions{
+		applyOpenShiftServiceServingCertCA(serviceaccountcontroller.TokensControllerOptions{
 			TokenGenerator: serviceaccount.JWTTokenGenerator(privateKey),
 			RootCA:         rootCA,
-		},
+		}),
 	)
 	if err != nil {
 		return true, fmt.Errorf("error creating Tokens controller: %v", err)

--- a/vendor/k8s.io/kubernetes/cmd/kube-controller-manager/app/patch.go
+++ b/vendor/k8s.io/kubernetes/cmd/kube-controller-manager/app/patch.go
@@ -1,6 +1,8 @@
 package app
 
 import (
+	"path"
+
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/rest"
 	"k8s.io/kubernetes/cmd/kube-controller-manager/app/options"
@@ -27,6 +29,11 @@ func ShimForOpenShift(controllerManager *options.CMServer, clientConfig *rest.Co
 	// TODO this should be replaced by the installer setting up the recycle template file and flags for us
 	cleanupFn, err := applyOpenShiftDefaultRecycler(controllerManager, openshiftConfig)
 	if err != nil {
+		return func() {}, err
+	}
+
+	// TODO this should be replaced by using a flex volume to inject service serving cert CAs into pods instead of adding it to the sa token
+	if err := applyOpenShiftServiceServingCertCAFunc(path.Dir(controllerManager.OpenShiftConfig), openshiftConfig); err != nil {
 		return func() {}, err
 	}
 

--- a/vendor/k8s.io/kubernetes/cmd/kube-controller-manager/app/patch_satoken.go
+++ b/vendor/k8s.io/kubernetes/cmd/kube-controller-manager/app/patch_satoken.go
@@ -1,0 +1,83 @@
+package app
+
+import (
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+
+	"github.com/openshift/origin/pkg/cmd/server/crypto"
+
+	serviceaccountcontroller "k8s.io/kubernetes/pkg/controller/serviceaccount"
+)
+
+var applyOpenShiftServiceServingCertCA = func(in serviceaccountcontroller.TokensControllerOptions) serviceaccountcontroller.TokensControllerOptions {
+	return in
+}
+
+func applyOpenShiftServiceServingCertCAFunc(openshiftConfigBase string, openshiftConfig map[string]interface{}) error {
+	serviceServingCertCAFilename := getServiceServingCertCAFilename(openshiftConfig)
+	if len(serviceServingCertCAFilename) == 0 {
+		return nil
+	}
+
+	resolvePath(&serviceServingCertCAFilename, openshiftConfigBase)
+
+	serviceServingCA, err := ioutil.ReadFile(serviceServingCertCAFilename)
+	if err != nil {
+		return fmt.Errorf("error reading ca file for Service Serving Certificate Signer: %s: %v", serviceServingCertCAFilename, err)
+	}
+	if _, err := crypto.CertsFromPEM(serviceServingCA); err != nil {
+		return fmt.Errorf("error parsing ca file for Service Serving Certificate Signer: %s: %v", serviceServingCertCAFilename, err)
+	}
+
+	applyOpenShiftServiceServingCertCA = func(controllerOptions serviceaccountcontroller.TokensControllerOptions) serviceaccountcontroller.TokensControllerOptions {
+		if len(serviceServingCA) == 0 {
+			return controllerOptions
+		}
+
+		// if we have a rootCA bundle add that too.  The rootCA will be used when hitting the default master service, since those are signed
+		// using a different CA by default.  The rootCA's key is more closely guarded than ours and if it is compromised, that power could
+		// be used to change the trusted signers for every pod anyway, so we're already effectively trusting it.
+		if len(controllerOptions.RootCA) > 0 {
+			controllerOptions.ServiceServingCA = append(controllerOptions.ServiceServingCA, controllerOptions.RootCA...)
+			controllerOptions.ServiceServingCA = append(controllerOptions.ServiceServingCA, []byte("\n")...)
+		}
+		controllerOptions.ServiceServingCA = append(controllerOptions.ServiceServingCA, serviceServingCA...)
+
+		return controllerOptions
+	}
+
+	return nil
+}
+
+func getServiceServingCertCAFilename(config map[string]interface{}) string {
+	controllerConfig, ok := config["controllerConfig"]
+	if !ok {
+		return ""
+	}
+	controllerConfigMap := controllerConfig.(map[string]interface{})
+	sscConfig, ok := controllerConfigMap["serviceServingCert"]
+	if !ok {
+		return ""
+	}
+	sscConfigMap := sscConfig.(map[string]interface{})
+	signerConfig, ok := sscConfigMap["signer"]
+	if !ok {
+		return ""
+	}
+	signerConfigMap := signerConfig.(map[string]interface{})
+	return signerConfigMap["certFile"].(string)
+}
+
+// resolvePath updates the given refs to be absolute paths, relative to the given base directory
+func resolvePath(ref *string, base string) error {
+	// Don't resolve empty paths
+	if len(*ref) > 0 {
+		// Don't resolve absolute paths
+		if !filepath.IsAbs(*ref) {
+			*ref = filepath.Join(base, *ref)
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
@deads2k docker for mac only mounts /Users, /Volumes, /private and /tmp by default... 

However:

```
$ echo $TMPDIR
/var/folders/jm/0vnz7tm15tl9g9n90cwqb3c00000gn/T/
```

That means golang ioutil.TempDir() use os.TempDir which will write all configs to location that cannot be mounted into container.... Using `/tmp` as os.TempDir in OSX seems to fix this.