### PR TITLE
use deployments for registry and router

### DIFF
--- a/pkg/oc/bootstrap/docker/openshift/admin.go
+++ b/pkg/oc/bootstrap/docker/openshift/admin.go
@@ -63,6 +63,7 @@ func (h *Helper) InstallRegistry(kubeClient kclientset.Interface, f *clientcmd.F
 		"--dry-run",
 		"--output=json",
 		"--local",
+		"--deployment-config=false",
 		fmt.Sprintf("--images=%s", images),
 		fmt.Sprintf("--mount-host=%s", path.Join(pvDir, "registry"))).Output()
 
@@ -179,6 +180,7 @@ func (h *Helper) InstallRouter(imageRunHelper *run.Runner, ocImage string, kubeC
 		"--output=json",
 		"--local",
 		"--host-ports=true",
+		"--deployment-config=false",
 		fmt.Sprintf("--host-network=%v", !portForwarding),
 		fmt.Sprintf("--images=%s", images),
 		fmt.Sprintf("--default-cert=%s", routerCertPath),


### PR DESCRIPTION
@deads2k willing to accept a little change to `oc adm`? I can do this separately, but this is a long overdue and there is no reason router and registry should use deployment configs as they have no hooks or image triggers defined.

This should speed up initial `oc cluster up` as we don't have to pull deployer image. 