### PR TITLE
fix admin.sh tests

### DIFF
--- a/pkg/oc/admin/node/node_options.go
+++ b/pkg/oc/admin/node/node_options.go
@@ -92,7 +92,6 @@ func (n *NodeOptions) Complete(f kcmdutil.Factory, c *cobra.Command, args []stri
 		return kcmdutil.PrinterForOptions(kcmdutil.ExtractCmdPrintOptions(c, withNamespace))
 	}
 
-	n.CmdPrinterOutput = true
 	if len(args) != 0 {
 		n.NodeNames = append(n.NodeNames, args...)
 	}

--- a/pkg/oc/admin/node/node_options.go
+++ b/pkg/oc/admin/node/node_options.go
@@ -129,7 +129,7 @@ func (n *NodeOptions) GetNodes() ([]*kapi.Node, error) {
 	}
 
 	r := n.Builder.
-		WithScheme(legacyscheme.Scheme, legacyscheme.Scheme.PrioritizedVersionsAllGroups()...).
+		WithScheme(legacyscheme.Scheme).
 		ContinueOnError().
 		NamespaceParam(n.DefaultNamespace).
 		LabelSelectorParam(n.Selector).

--- a/test/cmd/admin.sh
+++ b/test/cmd/admin.sh
@@ -117,7 +117,7 @@ echo "certs: ok"
 os::test::junit::declare_suite_end
 
 os::test::junit::declare_suite_start "cmd/admin/groups"
-os::cmd::expect_success_and_text 'oc adm groups new shortoutputgroup -o name' 'group/shortoutputgroup'
+os::cmd::expect_success_and_text 'oc adm groups new shortoutputgroup -o name' 'group.user.openshift.io/shortoutputgroup'
 os::cmd::expect_failure_and_text 'oc adm groups new shortoutputgroup' 'groups.user.openshift.io "shortoutputgroup" already exists'
 os::cmd::expect_failure_and_text 'oc adm groups new errorgroup -o blah' 'error: output format "blah" not recognized'
 os::cmd::expect_failure_and_text 'oc get groups/errorgroup' 'groups.user.openshift.io "errorgroup" not found'

--- a/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/util/printing.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/util/printing.go
@@ -136,13 +136,12 @@ func PrinterForOptions(options *printers.PrintOptions) (printers.ResourcePrinter
 	// TODO or be registered there
 	if humanReadablePrinter, ok := printer.(printers.PrintHandler); ok {
 		printersinternal.AddHandlers(humanReadablePrinter)
+	} else {
+		// wrap the printer in a versioning printer that understands when to convert and when not to convert
+		printer = printers.NewVersionedPrinter(printer, legacyscheme.Scheme, legacyscheme.Scheme, kubectlscheme.Scheme.PrioritizedVersionsAllGroups()...)
 	}
 
 	printer = maybeWrapSortingPrinter(printer, *options)
-
-	// wrap the printer in a versioning printer that understands when to convert and when not to convert
-	printer = printers.NewVersionedPrinter(printer, legacyscheme.Scheme, legacyscheme.Scheme, kubectlscheme.Scheme.PrioritizedVersionsAllGroups()...)
-
 	return printer, nil
 }
 


### PR DESCRIPTION
~~test/cmd/admin.sh:76 still fails due to the core.Node object being converted by the printer.
The command uses a `kcmdutil.PrinterForOptions` which returns a printer wrapped in a versioned printer: https://github.com/openshift/origin/blob/master/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/util/printing.go#L158~~ 

~~printers/internalversion/printHandlers are matched to internal objs~~

test/cmd/admin.sh:194 fails with:

```
FAILURE after 0.143s: test/cmd/admin.sh:194: executing 'oc delete clusterrole/cluster-status --cascade=false' expecting success: the command returned the wrong error code
Standard output from the command:
clusterrole.authorization.openshift.io "cluster-status" deleted

Standard error from the command:
Error from server (MethodNotAllowed): the server does not allow this method on the requested resource
[ERROR] [14:52:11-0400] PID 1325: hack/lib/cmd.sh:10: `return "${return_code}"` exited with status 1.
```