### PR TITLE
fix round-trip tests

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/api/testing/serialization_test.go
+++ b/vendor/k8s.io/kubernetes/pkg/api/testing/serialization_test.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/apimachinery/pkg/conversion"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	serializerjson "k8s.io/apimachinery/pkg/runtime/serializer/json"
 	"k8s.io/apimachinery/pkg/runtime/serializer/streaming"
 	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/apimachinery/pkg/util/json"
@@ -550,7 +551,7 @@ func BenchmarkDecodeIntoJSONCodecGenConfigFast(b *testing.B) {
 		encoded[i] = data
 	}
 
-	handler := &codec.JsonHandle{}
+	handler := serializerjson.NewUgorjiHandler()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/group_version_test.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/group_version_test.go
@@ -22,6 +22,8 @@ import (
 	"testing"
 
 	"github.com/ugorji/go/codec"
+
+	serializerjson "k8s.io/apimachinery/pkg/runtime/serializer/json"
 )
 
 type GroupVersionHolder struct {
@@ -50,7 +52,7 @@ func TestGroupVersionUnmarshalJSON(t *testing.T) {
 		// if err := jsoniter.ConfigCompatibleWithStandardLibrary.Unmarshal(c.input, &result); err != nil {
 		//   t.Errorf("json-iterator codec failed to unmarshal input '%v': %v", c.input, err)
 		// test the Ugorji codec
-		if err := codec.NewDecoderBytes(c.input, new(codec.JsonHandle)).Decode(&result); err != nil {
+		if err := codec.NewDecoderBytes(c.input, serializerjson.NewUgorjiHandler()).Decode(&result); err != nil {
 			t.Errorf("Ugorji codec failed to unmarshal input '%v': %v", c.input, err)
 		}
 		if !reflect.DeepEqual(result.GV, c.expect) {

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types_test.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types_test.go
@@ -22,6 +22,8 @@ import (
 	"testing"
 
 	"github.com/ugorji/go/codec"
+
+	serializerjson "k8s.io/apimachinery/pkg/runtime/serializer/json"
 )
 
 func TestVerbsUgorjiMarshalJSON(t *testing.T) {
@@ -59,7 +61,7 @@ func TestVerbsUgorjiUnmarshalJSON(t *testing.T) {
 	for i, c := range cases {
 		var result APIResource
 		// if err := jsoniter.ConfigCompatibleWithStandardLibrary.Unmarshal([]byte(c.input), &result); err != nil {
-		if err := codec.NewDecoderBytes([]byte(c.input), new(codec.JsonHandle)).Decode(&result); err != nil {
+		if err := codec.NewDecoderBytes([]byte(c.input), serializerjson.NewUgorjiHandler()).Decode(&result); err != nil {
 			t.Errorf("[%d] Failed to unmarshal input '%v': %v", i, c.input, err)
 		}
 		if !reflect.DeepEqual(result, c.result) {

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/json.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/json.go
@@ -30,6 +30,12 @@ import (
 	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
 )
 
+func NewUgorjiHandler() *codec.JsonHandle {
+	codecOptions := &codec.JsonHandle{}
+	codecOptions.SignedInteger = true
+	return codecOptions
+}
+
 // NewSerializer creates a JSON serializer that handles encoding versioned objects into the proper JSON form. If typer
 // is not nil, the object has the group, version, and kind fields set.
 func NewSerializer(meta MetaFactory, creater runtime.ObjectCreater, typer runtime.ObjectTyper, pretty bool) *Serializer {
@@ -131,7 +137,7 @@ func (s *Serializer) Decode(originalData []byte, gvk *schema.GroupVersionKind, i
 		switch {
 		case runtime.IsNotRegisteredError(err), isUnstructured:
 			// if err := jsoniter.ConfigCompatibleWithStandardLibrary.Unmarshal(data, into); err != nil {
-			if err := codec.NewDecoderBytes(data, new(codec.JsonHandle)).Decode(into); err != nil {
+			if err := codec.NewDecoderBytes(data, NewUgorjiHandler()).Decode(into); err != nil {
 				return nil, actual, err
 			}
 			return into, actual, nil
@@ -156,7 +162,7 @@ func (s *Serializer) Decode(originalData []byte, gvk *schema.GroupVersionKind, i
 	}
 
 	// if err := jsoniter.ConfigCompatibleWithStandardLibrary.Unmarshal(data, obj); err != nil {
-	if err := codec.NewDecoderBytes(data, new(codec.JsonHandle)).Decode(obj); err != nil {
+	if err := codec.NewDecoderBytes(data, NewUgorjiHandler()).Decode(obj); err != nil {
 		return nil, actual, err
 	}
 	return obj, actual, nil

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/diff/diff.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/diff/diff.go
@@ -108,6 +108,14 @@ func limit(aObj, bObj interface{}, max int) (string, string) {
 	elidedASuffix := ""
 	elidedBSuffix := ""
 	a, b := fmt.Sprintf("%#v", aObj), fmt.Sprintf("%#v", bObj)
+
+	if aObj != nil && bObj != nil {
+		if aType, bType := fmt.Sprintf("%T", aObj), fmt.Sprintf("%T", bObj); aType != bType {
+			a = fmt.Sprintf("%s (%s)", a, aType)
+			b = fmt.Sprintf("%s (%s)", b, bType)
+		}
+	}
+
 	for {
 		switch {
 		case len(a) > max && len(a) > 4 && len(b) > 4 && a[:4] == b[:4]:

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/diff/diff_test.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/diff/diff_test.go
@@ -75,6 +75,11 @@ object.A:
   a: []int(nil)
   b: []int{}`,
 		},
+		"display type differences": {a: []interface{}{int64(1)}, b: []interface{}{uint64(1)}, out: `
+object[0]:
+  a: 1 (int64)
+  b: 0x1 (uint64)`,
+		},
 	}
 	for name, test := range testCases {
 		expect := test.out


### PR DESCRIPTION
adjust ugorji decoding to match json-iter decoding to pull unstructured integers into signed ints